### PR TITLE
Speed up checks and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,25 @@ concurrency:
 
 jobs:
   checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+
+  full:
+    if: github.event_name == 'push'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,32 +38,22 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install engine dependencies
+        run: |
+          bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
+          bun install --frozen-lockfile --cwd engine/opencode
+
+      - name: Engine tests
+        run: bun run test:engine
+
+      - name: Build engine
+        run: bun run build:engine
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'engine/upstream/bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: |
-          bun install
-          bun install --ignore-scripts --cwd engine/upstream
-          bun install --cwd engine/opencode
-
-      - name: Typecheck
-        run: bun run typecheck
-
-      - name: Test
-        run: bun run test
-
-      - name: Build engine
-        run: bun run build:engine
 
       - name: Native unit tests
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          bun install --frozen-lockfile
+          bun install --frozen-lockfile --cwd engine/opencode
 
       - name: Typecheck
         run: bun run typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,11 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock', 'engine/upstream/bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-
       - name: Install dependencies
         run: |
-          bun install
-          bun install --ignore-scripts --cwd engine/upstream
-          bun install --cwd engine/opencode
+          bun install --frozen-lockfile
+          bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
+          bun install --frozen-lockfile --cwd engine/opencode
 
       - name: Build engine
         run: bun run build:engine


### PR DESCRIPTION
## Summary

- run required PR checks on Linux with only the root and extension dependency installs, typecheck, and 117 fast tests
- move engine and Rust validation to a separate Windows job that runs after merges instead of blocking PR approval
- remove the Bun cache restore from CI and releases; historical restores took 2:05-3:39 while uncached installs took 36-42 seconds
- use frozen lockfiles for deterministic installs

## Measured result

PR checks now pass in 18 seconds end to end, down from 4:36-7:08. Native release builds still require Rust compilation and signing, but removing the counterproductive cache saves multiple minutes.

## Validation

- all frozen-lockfile install commands passed
- `bun run typecheck`
- `bun run test` (117 passed)
- GitHub Actions `checks` job passed in 18 seconds
- `git diff --check`