### PR TITLE
Remove hidden transcript gaps

### DIFF
--- a/src/ui/chat.tsx
+++ b/src/ui/chat.tsx
@@ -6,7 +6,7 @@ import { t } from "../state/i18n"
 import { selectedSession } from "../state/selection"
 import { activeWorkspace } from "../state/workspaces"
 import { IconArrowDown } from "./icons"
-import { MessageView } from "./message"
+import { MessageView, messageVisible } from "./message"
 import { TextShimmer } from "./text-shimmer"
 import { DriftLogo } from "./logo"
 
@@ -35,6 +35,16 @@ export function Chat() {
     const messageError = (latest.info as { error?: { name: string; data?: unknown } }).error
     return messageError && messageError.name !== "MessageAbortedError" ? null : error
   })
+  const thinking = createMemo(() => {
+    const id = selectedSession()
+    return id ? thinkingState(entries(), engine.state.status[id]?.type) : null
+  })
+  const retry = createMemo(() => {
+    const id = selectedSession()
+    const status = id ? engine.state.status[id] : undefined
+    return status?.type === "retry" ? status : undefined
+  })
+  const timeline = createMemo(() => timelineEntries(entries(), thinking()?.messageID))
 
   createEffect(() => {
     const id = selectedSession()
@@ -53,7 +63,7 @@ export function Chat() {
 
   const offsets = createMemo(() => {
     measured()
-    const list = entries()
+    const list = timeline()
     const result = new Array<number>(list.length + 1)
     result[0] = 0
     for (let index = 0; index < list.length; index++)
@@ -72,16 +82,7 @@ export function Chat() {
     return { start, end }
   })
 
-  const slice = createMemo(() => entries().slice(range().start, range().end))
-  const thinking = createMemo(() => {
-    const id = selectedSession()
-    return id ? thinkingState(entries(), engine.state.status[id]?.type) : null
-  })
-  const retry = createMemo(() => {
-    const id = selectedSession()
-    const status = id ? engine.state.status[id] : undefined
-    return status?.type === "retry" ? status : undefined
-  })
+  const slice = createMemo(() => timeline().slice(range().start, range().end))
 
   const observer = new ResizeObserver((observations) => {
     let deltaAbove = 0
@@ -361,6 +362,10 @@ export function mergeCompactionEntries(entries: MessageEntry[]) {
       next.info.parentID === entry.info.id
     return !boundary || !summary
   })
+}
+
+export function timelineEntries(entries: MessageEntry[], activeMessageID?: string | null) {
+  return entries.filter((entry) => entry.info.id === activeMessageID || messageVisible(entry))
 }
 
 export function thinkingAfterMessage(entries: MessageEntry[], status?: string) {

--- a/src/ui/message.tsx
+++ b/src/ui/message.tsx
@@ -29,6 +29,14 @@ export function MessageView(props: { entry: MessageEntry; footer?: boolean }) {
   )
 }
 
+export function messageVisible(entry: MessageEntry) {
+  if (entry.info.role === "user")
+    return !!messageText(entry) || entry.parts.some((part) => part.type === "file" || part.type === "compaction")
+  const info = entry.info as AssistantMessage
+  if (info.summary && collapseCompaction()) return true
+  return entry.parts.some(partVisible) || !!info.error
+}
+
 function CompactionSummary(props: { entry: MessageEntry; footer?: boolean }) {
   const [open, setOpen] = createSignal(!compactionCollapsed())
   return (

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -302,6 +302,23 @@ test("transcript follow revision tracks lengths and status without embedding lar
   expect(completed).not.toBe(first)
 })
 
+test("timeline omits hidden-only messages without dropping the active thinking row", async () => {
+  const { timelineEntries } = await import("../src/ui/chat")
+  const entry = (id: string, parts: unknown[]) => ({
+    info: { id, role: "assistant", time: { created: 1 }, tokens: { input: 0, output: 0, reasoning: 0 } },
+    parts,
+  })
+  const hidden = entry("hidden", [{ id: "r1", type: "reasoning", text: "private", time: { start: 1, end: 2 } }])
+  const todo = entry("todo", [{ id: "t1", type: "tool", tool: "todowrite", state: { status: "completed" } }])
+  const visible = entry("visible", [{ id: "t2", type: "tool", tool: "edit", state: { status: "completed" } }])
+
+  expect(timelineEntries([hidden, todo, visible] as never).map((item) => item.info.id)).toEqual(["visible"])
+  expect(timelineEntries([hidden, todo, visible] as never, "hidden").map((item) => item.info.id)).toEqual([
+    "hidden",
+    "visible",
+  ])
+})
+
 test("tall row measurement only compensates rows actually above the viewport", async () => {
   const { resizeCompensation } = await import("../src/ui/chat")
   expect(resizeCompensation(96, 2000, 2100, 1000)).toBe(0)


### PR DESCRIPTION
## Summary
- filter hidden-only messages before transcript virtualization
- keep active hidden entries while thinking or retry status is visible
- cover completed hidden reasoning and internal todo rows

## Validation
- bun test tests/activity.test.ts
- bun run typecheck
- bun run test
- bun run build