### PR TITLE
Stabilize streaming message rendering

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -912,10 +912,9 @@ pre.code-display {
 }
 
 .md :where(table) {
-  display: block;
-  width: max-content;
+  width: 100%;
   max-width: 100%;
-  overflow-x: auto;
+  table-layout: fixed;
   border-collapse: separate;
   border-spacing: 0;
   border: 1px solid var(--edge);
@@ -928,7 +927,7 @@ pre.code-display {
   text-align: left;
   vertical-align: top;
   word-break: normal;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   border-bottom: 1px solid color-mix(in srgb, var(--edge) 72%, transparent);
 }
 
@@ -936,7 +935,6 @@ pre.code-display {
   background: var(--raised);
   border-bottom-color: var(--edge);
   font-weight: 600;
-  white-space: nowrap;
 }
 
 .md :where(tr:last-child td) {

--- a/src/ui/message.tsx
+++ b/src/ui/message.tsx
@@ -116,6 +116,8 @@ function UserBubble(props: { entry: MessageEntry }) {
 
 export type PartGroup = { id: string; key: string; explored: ToolPart[] } | { id: string; key: string; part: Part }
 
+export type PartGroupSlot = { id: string; value: PartGroup; update: (value: PartGroup) => void }
+
 export function groupParts(parts: Part[]): PartGroup[] {
   const groups: PartGroup[] = []
   for (const part of parts) {
@@ -131,19 +133,46 @@ export function groupParts(parts: Part[]): PartGroup[] {
   return groups
 }
 
+function createPartGroupSlot(group: PartGroup): PartGroupSlot {
+  const [value, setValue] = createStore(group)
+  return { id: group.id, value, update: (updated) => setValue(reconcile(updated)) }
+}
+
+export function updatePartGroupSlots(
+  groups: PartGroup[],
+  slots: Map<string, PartGroupSlot>,
+  createSlot = createPartGroupSlot,
+) {
+  const active = new Set<string>()
+  const next = groups.map((group) => {
+    active.add(group.id)
+    const existing = slots.get(group.id)
+    if (existing) {
+      existing.update(group)
+      return existing
+    }
+    const slot = createSlot(group)
+    slots.set(group.id, slot)
+    return slot
+  })
+  for (const id of slots.keys()) if (!active.has(id)) slots.delete(id)
+  return next
+}
+
 function AssistantFlow(props: { entry: MessageEntry; footer?: boolean }) {
   const info = () => props.entry.info as AssistantMessage
-  const [groups, setGroups] = createStore(groupParts(props.entry.parts))
-  createRenderEffect(() => setGroups(reconcile(groupParts(props.entry.parts))))
+  const slots = new Map<string, PartGroupSlot>()
+  const [groups, setGroups] = createSignal<PartGroupSlot[]>([])
+  createRenderEffect(() => setGroups(updatePartGroupSlots(groupParts(props.entry.parts), slots)))
   const visible = () => props.entry.parts.some(partVisible) || !!info().error
   return (
     <Show when={visible()}>
       <div class="group flex min-w-0 max-w-full flex-col gap-3">
-        <For each={groups}>
+        <For each={groups()}>
           {(group) => (
             <Switch>
-              <Match when={"explored" in group && group}>{(g) => <ExploredGroup parts={g().explored} />}</Match>
-              <Match when={"part" in group && group}>{(g) => <PartView part={g().part} />}</Match>
+              <Match when={"explored" in group.value && group.value}>{(g) => <ExploredGroup parts={g().explored} />}</Match>
+              <Match when={"part" in group.value && group.value}>{(g) => <PartView part={g().part} />}</Match>
             </Switch>
           )}
         </For>

--- a/src/ui/message.tsx
+++ b/src/ui/message.tsx
@@ -143,10 +143,38 @@ export function updatePartGroupSlots(
   slots: Map<string, PartGroupSlot>,
   createSlot = createPartGroupSlot,
 ) {
+  const previous = [...slots.values()]
+  const exploredByPart = new Map<string, { index: number; slot: PartGroupSlot }>()
+  previous.forEach((slot, index) => {
+    if (!("explored" in slot.value)) return
+    slot.value.explored.forEach((part) => exploredByPart.set(part.id, { index, slot }))
+  })
+  // A split can overlap one prior group more than once; its anchor-containing fragment owns the old mount.
+  const reserved = new Map<string, number>()
+  previous.forEach((slot) => {
+    if (!("explored" in slot.value)) return
+    const owner = groups.findIndex(
+      (group) => "explored" in group && group.explored.some((part) => `explored:${part.id}` === slot.id),
+    )
+    if (owner !== -1) reserved.set(slot.id, owner)
+  })
+  const claimed = new Set<string>()
   const active = new Set<string>()
-  const next = groups.map((group) => {
+  const next = groups.map((input, index) => {
+    const existing = "explored" in input
+      ? input.explored.reduce<{ index: number; slot: PartGroupSlot } | undefined>((result, part) => {
+          const candidate = exploredByPart.get(part.id)
+          if (!candidate || claimed.has(candidate.slot.id)) return result
+          const owner = reserved.get(candidate.slot.id)
+          if (owner !== undefined && owner !== index) return result
+          return !result || candidate.index < result.index ? candidate : result
+        }, undefined)?.slot
+      : slots.get(input.id)
+    const group = existing && input.id !== existing.id
+      ? { ...input, id: existing.id, key: existing.id }
+      : input
+    if (existing && "explored" in input) claimed.add(existing.id)
     active.add(group.id)
-    const existing = slots.get(group.id)
     if (existing) {
       existing.update(group)
       return existing
@@ -156,6 +184,10 @@ export function updatePartGroupSlots(
     return slot
   })
   for (const id of slots.keys()) if (!active.has(id)) slots.delete(id)
+  for (const slot of next) {
+    slots.delete(slot.id)
+    slots.set(slot.id, slot)
+  }
   return next
 }
 

--- a/src/ui/message.tsx
+++ b/src/ui/message.tsx
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Part, ToolPart, UserMessage } from "@opencode-ai/sdk/client"
-import { createMemo, createSignal, For, Match, onMount, Show, Switch } from "solid-js"
+import { createRenderEffect, createSignal, For, Match, onMount, Show, Switch } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
 import { useEngine } from "../engine"
 import { errorText } from "../engine/error"
 import { messageText, modelInfo, type MessageEntry } from "../engine/store"
@@ -113,31 +114,32 @@ function UserBubble(props: { entry: MessageEntry }) {
   )
 }
 
-type PartGroup = { key: string; explored: ToolPart[] } | { key: string; part: Part }
+export type PartGroup = { id: string; key: string; explored: ToolPart[] } | { id: string; key: string; part: Part }
 
-function groupParts(parts: Part[]): PartGroup[] {
+export function groupParts(parts: Part[]): PartGroup[] {
   const groups: PartGroup[] = []
   for (const part of parts) {
     if (!partVisible(part)) continue
     if (part.type === "tool" && contextTools.has(part.tool)) {
       const last = groups.at(-1)
       if (last && "explored" in last) last.explored.push(part)
-      else groups.push({ key: `explored:${part.id}`, explored: [part] })
+      else groups.push({ id: `explored:${part.id}`, key: `explored:${part.id}`, explored: [part] })
       continue
     }
-    groups.push({ key: part.id, part })
+    groups.push({ id: part.id, key: part.id, part })
   }
   return groups
 }
 
 function AssistantFlow(props: { entry: MessageEntry; footer?: boolean }) {
   const info = () => props.entry.info as AssistantMessage
-  const groups = createMemo(() => groupParts(props.entry.parts))
+  const [groups, setGroups] = createStore(groupParts(props.entry.parts))
+  createRenderEffect(() => setGroups(reconcile(groupParts(props.entry.parts))))
   const visible = () => props.entry.parts.some(partVisible) || !!info().error
   return (
     <Show when={visible()}>
       <div class="group flex min-w-0 max-w-full flex-col gap-3">
-        <For each={groups()}>
+        <For each={groups}>
           {(group) => (
             <Switch>
               <Match when={"explored" in group && group}>{(g) => <ExploredGroup parts={g().explored} />}</Match>

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -172,13 +172,17 @@ test("compaction-only user messages retain their delimiter part", async () => {
 })
 
 test("streamed tool replacements retain mounted group and plugin identities", async () => {
-  const { groupParts } = await import("../src/ui/message")
+  const { groupParts, updatePartGroupSlots } = await import("../src/ui/message")
   // Bun selects Solid's server condition for tests, so load the browser primitives
   // used by Vite to verify the keyed mount behavior without requiring a DOM.
   // @ts-expect-error Solid's browser build shares the package's public types.
-  const { createRoot, mapArray, onCleanup } = await import("solid-js/dist/solid.js") as typeof import("solid-js")
+  const { createRoot, createSignal, mapArray, onCleanup } = await import("solid-js/dist/solid.js") as typeof import("solid-js")
   // @ts-expect-error Solid's browser store build shares the package's public types.
   const { createStore, reconcile } = await import("solid-js/store/dist/store.js") as typeof import("solid-js/store")
+  const createSlot = (group: ReturnType<typeof groupParts>[number]) => {
+    const [value, setValue] = createStore(group)
+    return { id: group.id, value, update: (updated: typeof group) => setValue(reconcile(updated)) }
+  }
   const tool = (id: string, name: string, status: string, output = "") => ({
     id,
     sessionID: "s1",
@@ -191,48 +195,57 @@ test("streamed tool replacements retain mounted group and plugin identities", as
   })
 
   createRoot((dispose) => {
-    const [groups, setGroups] = createStore(groupParts([
+    const slots = new Map()
+    const initial = updatePartGroupSlots(groupParts([
       tool("shell", "bash", "running", "first"),
       tool("plugin", "custom-stream", "running", "one"),
       tool("read-1", "read", "running"),
       tool("grep-1", "grep", "running"),
-    ] as never))
+    ] as never), slots, createSlot)
+    const [groups, setGroups] = createSignal(initial)
     let mounts = 0
     let cleanups = 0
     const mounted = mapArray(
-      () => groups,
-      (group) => {
+      groups,
+      (slot) => {
         mounts++
         const state = { scrollTop: 37, following: false, pluginRevision: 4 }
         onCleanup(() => cleanups++)
-        return { group, state }
+        return { slot, state }
       },
     )
     const first = mounted()
-    const firstExplored = "explored" in first[2].group ? [...first[2].group.explored] : []
+    const firstById = new Map(first.map((item) => [item.slot.id, item]))
+    const explored = firstById.get("explored:read-1")!.slot.value
+    const firstExplored = "explored" in explored ? [...explored.explored] : []
     expect(mounts).toBe(3)
 
-    setGroups(reconcile(groupParts([
-      tool("shell", "bash", "running", "first\nsecond"),
+    setGroups(updatePartGroupSlots(groupParts([
+      { id: "text", sessionID: "s1", messageID: "m1", type: "text", text: "Now visible" },
       tool("plugin", "custom-stream", "completed", "two"),
+      tool("shell", "bash", "running", "first\nsecond"),
       tool("read-1", "read", "completed"),
       tool("grep-1", "grep", "completed"),
-    ] as never)))
+    ] as never), slots, createSlot))
     const updated = mounted()
-    expect(updated.map((item) => item.group.key)).toEqual(["shell", "plugin", "explored:read-1"])
-    expect(updated.every((item, index) => item === first[index])).toBeTrue()
-    expect(updated[0].state).toEqual({ scrollTop: 37, following: false, pluginRevision: 4 })
-    expect(updated[1].state.pluginRevision).toBe(4)
-    expect("explored" in updated[2].group && updated[2].group.explored.map((part) => part.id)).toEqual([
+    const updatedById = new Map(updated.map((item) => [item.slot.id, item]))
+    expect(updated.map((item) => item.slot.id)).toEqual(["text", "plugin", "shell", "explored:read-1"])
+    expect(updatedById.get("shell")).toBe(firstById.get("shell"))
+    expect(updatedById.get("plugin")).toBe(firstById.get("plugin"))
+    expect(updatedById.get("explored:read-1")).toBe(firstById.get("explored:read-1"))
+    expect(updatedById.get("shell")!.state).toEqual({ scrollTop: 37, following: false, pluginRevision: 4 })
+    expect(updatedById.get("plugin")!.state.pluginRevision).toBe(4)
+    const updatedExplored = updatedById.get("explored:read-1")!.slot.value
+    expect("explored" in updatedExplored && updatedExplored.explored.map((part) => part.id)).toEqual([
       "read-1",
       "grep-1",
     ])
-    expect("explored" in updated[2].group && updated[2].group.explored[0]).toBe(firstExplored[0])
-    expect("explored" in updated[2].group && updated[2].group.explored[1]).toBe(firstExplored[1])
-    expect(mounts).toBe(3)
+    expect("explored" in updatedExplored && updatedExplored.explored[0]).toBe(firstExplored[0])
+    expect("explored" in updatedExplored && updatedExplored.explored[1]).toBe(firstExplored[1])
+    expect(mounts).toBe(4)
     expect(cleanups).toBe(0)
     dispose()
-    expect(cleanups).toBe(3)
+    expect(cleanups).toBe(4)
   })
 })
 

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -200,7 +200,7 @@ test("streamed tool replacements retain mounted group and plugin identities", as
       tool("shell", "bash", "running", "first"),
       tool("plugin", "custom-stream", "running", "one"),
       tool("read-1", "read", "running"),
-      tool("grep-1", "grep", "running"),
+      tool("read-2", "read", "running"),
     ] as never), slots, createSlot)
     const [groups, setGroups] = createSignal(initial)
     let mounts = 0
@@ -224,8 +224,9 @@ test("streamed tool replacements retain mounted group and plugin identities", as
       { id: "text", sessionID: "s1", messageID: "m1", type: "text", text: "Now visible" },
       tool("plugin", "custom-stream", "completed", "two"),
       tool("shell", "bash", "running", "first\nsecond"),
+      tool("read-0", "read", "completed"),
       tool("read-1", "read", "completed"),
-      tool("grep-1", "grep", "completed"),
+      tool("read-2", "read", "completed"),
     ] as never), slots, createSlot))
     const updated = mounted()
     const updatedById = new Map(updated.map((item) => [item.slot.id, item]))
@@ -237,15 +238,38 @@ test("streamed tool replacements retain mounted group and plugin identities", as
     expect(updatedById.get("plugin")!.state.pluginRevision).toBe(4)
     const updatedExplored = updatedById.get("explored:read-1")!.slot.value
     expect("explored" in updatedExplored && updatedExplored.explored.map((part) => part.id)).toEqual([
+      "read-0",
       "read-1",
-      "grep-1",
+      "read-2",
     ])
-    expect("explored" in updatedExplored && updatedExplored.explored[0]).toBe(firstExplored[0])
-    expect("explored" in updatedExplored && updatedExplored.explored[1]).toBe(firstExplored[1])
+    expect("explored" in updatedExplored && updatedExplored.explored[1]).toBe(firstExplored[0])
+    expect("explored" in updatedExplored && updatedExplored.explored[2]).toBe(firstExplored[1])
     expect(mounts).toBe(4)
     expect(cleanups).toBe(0)
+
+    setGroups(updatePartGroupSlots(groupParts([
+      tool("read-2", "read", "completed"),
+      { id: "divider", sessionID: "s1", messageID: "m1", type: "text", text: "Split" },
+      tool("read-0", "read", "completed"),
+      tool("read-1", "read", "completed"),
+    ] as never), slots, createSlot))
+    const split = mounted()
+    const splitExplored = split.filter((item) => "explored" in item.slot.value)
+    expect(splitExplored.map((item) => item.slot.id)).toEqual(["explored:read-2", "explored:read-1"])
+    expect(splitExplored[0]).not.toBe(firstById.get("explored:read-1"))
+    expect(splitExplored[1]).toBe(firstById.get("explored:read-1"))
+
+    setGroups(updatePartGroupSlots(groupParts([
+      tool("read-2", "read", "completed"),
+      tool("read-0", "read", "completed"),
+      tool("read-1", "read", "completed"),
+    ] as never), slots, createSlot))
+    const merged = mounted()
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toBe(splitExplored[0])
+    expect(merged[0].slot.id).toBe("explored:read-2")
     dispose()
-    expect(cleanups).toBe(4)
+    expect(cleanups).toBe(mounts)
   })
 })
 

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -55,6 +55,23 @@ test("markdown preserves balanced, void, and code-fenced HTML", async () => {
   expect(prepareMarkdown("orphan </strong> text")).toBe("orphan &lt;/strong&gt; text")
 })
 
+test("streaming tables bound incomplete links and preserve completed anchors", async () => {
+  const { prepareMarkdown } = await import("../src/ui/markdown")
+  const { marked } = await import("marked")
+  const url = `https://example.com/${"long-segment".repeat(20)}`
+  const prefix = "| Resource | State |\n| --- | --- |\n"
+  const incomplete = marked.parse(prepareMarkdown(`${prefix}| [documentation](${url} | loading |`), { async: false })
+  const complete = marked.parse(prepareMarkdown(`${prefix}| [documentation](${url}) | ready |`), { async: false })
+  expect(incomplete).toContain("<table>")
+  expect(incomplete).toContain(url)
+  expect(incomplete).toContain(`>${url}</a>`)
+  expect(complete).toContain(`<a href="${url}">documentation</a>`)
+
+  const css = await Bun.file(new URL("../src/styles/app.css", import.meta.url)).text()
+  expect(css).toMatch(/\.md :where\(table\) \{[^}]*width: 100%;[^}]*table-layout: fixed;/s)
+  expect(css).toMatch(/\.md :where\(th, td\) \{[^}]*overflow-wrap: anywhere;/s)
+})
+
 test("user markdown preserves literal Windows path backslashes", async () => {
   const { prepareMarkdown } = await import("../src/ui/markdown")
   expect(prepareMarkdown("Open \\\\server\\share\\folder", true)).toBe(
@@ -152,6 +169,71 @@ test("compaction-only user messages retain their delimiter part", async () => {
     parts: [{ id: "p1", messageID: "m1", sessionID: "s1", type: "compaction", auto: true }],
   } as never
   expect(compactionParts(entry).map((part) => part.id)).toEqual(["p1"])
+})
+
+test("streamed tool replacements retain mounted group and plugin identities", async () => {
+  const { groupParts } = await import("../src/ui/message")
+  // Bun selects Solid's server condition for tests, so load the browser primitives
+  // used by Vite to verify the keyed mount behavior without requiring a DOM.
+  // @ts-expect-error Solid's browser build shares the package's public types.
+  const { createRoot, mapArray, onCleanup } = await import("solid-js/dist/solid.js") as typeof import("solid-js")
+  // @ts-expect-error Solid's browser store build shares the package's public types.
+  const { createStore, reconcile } = await import("solid-js/store/dist/store.js") as typeof import("solid-js/store")
+  const tool = (id: string, name: string, status: string, output = "") => ({
+    id,
+    sessionID: "s1",
+    messageID: "m1",
+    type: "tool",
+    tool: name,
+    state: status === "completed"
+      ? { status, input: {}, output }
+      : { status, input: {}, metadata: { output } },
+  })
+
+  createRoot((dispose) => {
+    const [groups, setGroups] = createStore(groupParts([
+      tool("shell", "bash", "running", "first"),
+      tool("plugin", "custom-stream", "running", "one"),
+      tool("read-1", "read", "running"),
+      tool("grep-1", "grep", "running"),
+    ] as never))
+    let mounts = 0
+    let cleanups = 0
+    const mounted = mapArray(
+      () => groups,
+      (group) => {
+        mounts++
+        const state = { scrollTop: 37, following: false, pluginRevision: 4 }
+        onCleanup(() => cleanups++)
+        return { group, state }
+      },
+    )
+    const first = mounted()
+    const firstExplored = "explored" in first[2].group ? [...first[2].group.explored] : []
+    expect(mounts).toBe(3)
+
+    setGroups(reconcile(groupParts([
+      tool("shell", "bash", "running", "first\nsecond"),
+      tool("plugin", "custom-stream", "completed", "two"),
+      tool("read-1", "read", "completed"),
+      tool("grep-1", "grep", "completed"),
+    ] as never)))
+    const updated = mounted()
+    expect(updated.map((item) => item.group.key)).toEqual(["shell", "plugin", "explored:read-1"])
+    expect(updated.every((item, index) => item === first[index])).toBeTrue()
+    expect(updated[0].state).toEqual({ scrollTop: 37, following: false, pluginRevision: 4 })
+    expect(updated[1].state.pluginRevision).toBe(4)
+    expect("explored" in updated[2].group && updated[2].group.explored.map((part) => part.id)).toEqual([
+      "read-1",
+      "grep-1",
+    ])
+    expect("explored" in updated[2].group && updated[2].group.explored[0]).toBe(firstExplored[0])
+    expect("explored" in updated[2].group && updated[2].group.explored[1]).toBe(firstExplored[1])
+    expect(mounts).toBe(3)
+    expect(cleanups).toBe(0)
+    dispose()
+    expect(cleanups).toBe(3)
+  })
 })
 
 test("compaction boundary merges into its adjacent summary", async () => {


### PR DESCRIPTION
Fixes #18 and #22. Tool groups now retain stable mounted identities across streamed part replacement, insertion, and reordering, preserving one-shot animation and shell/plugin local state. Markdown tables use bounded fixed geometry and cell wrapping so incomplete long links cannot resize the table while completed links remain labeled and clickable. Regression coverage exercises both incomplete/completed table links and keyed tool-group lifecycle behavior.