### PR TITLE
Harden engine recovery

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -72,12 +72,11 @@ export function createActions(
 ) {
   const pageSize = 100
   let allSessionsRequest: { token: ReturnType<RecoveryCoordinator["begin"]>; promise: Promise<void> } | undefined
-  const sessionRequests = new Map<
-    string,
-    { token: ReturnType<RecoveryCoordinator["begin"]>; promise: Promise<boolean> }
-  >()
+  const sessionRequests = new Map<string, { generation: number; promise: Promise<boolean> }>()
 
   const sessionEvents = (entry: BufferedEvent) => isSessionEvent(entry.event)
+  const sessionEventsIn = (directory: string) => (entry: BufferedEvent) =>
+    isSessionEvent(entry.event) && eventInDirectory(entry, directory)
   const transcriptEvents = (id: string) => (entry: BufferedEvent) =>
     isTranscriptEvent(entry.event) && sessionID(entry.event) === id
 
@@ -92,7 +91,11 @@ export function createActions(
     }
   }
 
-  async function requestTranscript(id: string, token: ReturnType<RecoveryCoordinator["begin"]>) {
+  async function requestTranscript(
+    id: string,
+    token: ReturnType<RecoveryCoordinator["begin"]>,
+    loadedAtStart: boolean,
+  ) {
     try {
       const result = await requireClient().session.messages({
         path: { id },
@@ -102,7 +105,7 @@ export function createActions(
       const entries = [...requireSdkData(result, "Could not load the session transcript")].sort((a, b) =>
         a.info.id.localeCompare(b.info.id),
       )
-      let applied = false
+      let applied: ReturnType<typeof applyTranscriptSnapshot> | undefined
       const committed = recovery.commit(token, (events) => {
         applied = applyTranscriptSnapshot(
           state,
@@ -111,24 +114,26 @@ export function createActions(
           entries,
           result.response?.headers?.get("x-next-cursor") ?? null,
           events,
-          recovery.replay,
+          loadedAtStart,
         )
       })
-      if (applied) recordLinks(entries)
-      return committed && applied
+      if (applied === "applied") recordLinks(entries)
+      return committed ? applied : undefined
     } finally {
       recovery.cancel(token)
     }
   }
 
   async function reloadSession(id: string) {
-    for (let attempt = 0; attempt < 2; attempt += 1) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const loadedAtStart = state.loaded[id] === true
       const token = recovery.begin(transcriptEvents(id))
       try {
-        const loaded = await requestTranscript(id, token)
-        if (loaded || token.generation !== recovery.generation()) return loaded
+        const result = await requestTranscript(id, token, loadedAtStart)
+        if (result === "applied") return true
+        if (result !== "retry" || token.generation !== recovery.generation()) return false
       } catch (error) {
-        if (token.generation !== recovery.generation() || !token.invalid || attempt > 0) throw error
+        if (token.generation !== recovery.generation() || !token.invalid || attempt > 1) throw error
       }
     }
     return false
@@ -172,16 +177,16 @@ export function createActions(
   function openSession(id: string) {
     if (state.loaded[id]) return Promise.resolve(true)
     const current = sessionRequests.get(id)
-    if (current && recovery.current(current.token)) return current.promise
+    if (current && current.generation === recovery.generation()) return current.promise
     if (current) sessionRequests.delete(id)
-    const token = recovery.begin(transcriptEvents(id))
-    let entry: { token: typeof token; promise: Promise<boolean> } | undefined
+    const generation = recovery.generation()
+    let entry: { generation: number; promise: Promise<boolean> } | undefined
     const request = (async () => {
       set("loading", id, true)
       try {
-        return await requestTranscript(id, token)
+        return await reloadSession(id)
       } catch (error) {
-        if (!token.signal.aborted)
+        if (generation === recovery.generation())
           notice({
             title: "Transcript load failed",
             message: error instanceof Error ? error.message : "Could not load the session transcript",
@@ -197,7 +202,7 @@ export function createActions(
           )
       }
     })()
-    entry = { token, promise: request }
+    entry = { generation, promise: request }
     sessionRequests.set(id, entry)
     void request.finally(() => {
       if (entry && sessionRequests.get(id) === entry) sessionRequests.delete(id)
@@ -206,7 +211,7 @@ export function createActions(
   }
 
   async function loadSessions(directory: string) {
-    const token = recovery.begin(sessionEvents)
+    const token = recovery.begin(sessionEventsIn(directory))
     try {
       const result = await requireClient().session.list({ query: { directory }, signal: token.signal })
       const sessions = requireSdkData(result, "Could not load sessions")
@@ -606,14 +611,16 @@ export function createActions(
   // raised while we weren't listening. Walk directories one at a time so idle workspaces
   // don't stampede instance boots on a timer.
   const pendingDirectories = new Map<string, string>()
-  let activeDirectories = new Set<string>()
+  let activeDirectories = new Map<string, string>()
+  let permissionGeneration: number | undefined
   let permissionRequest: Promise<void> | undefined
 
   function refreshPermissions(directories: string[]) {
     if (!target()) return Promise.resolve()
     for (const directory of directories) {
       const key = normalizeDir(directory)
-      if (!key || activeDirectories.has(key)) continue
+      if (!key) continue
+      if (activeDirectories.has(key) && permissionGeneration === recovery.generation()) continue
       pendingDirectories.set(key, directory)
     }
     if (permissionRequest) return permissionRequest
@@ -628,11 +635,27 @@ export function createActions(
       while (pendingDirectories.size) {
         const directories = [...pendingDirectories.entries()]
         pendingDirectories.clear()
-        activeDirectories = new Set(directories.map(([key]) => key))
-        for (const [, directory] of directories) await refreshDirectoryAsks(directory)
+        const generation = recovery.generation()
+        permissionGeneration = generation
+        activeDirectories = new Map(directories)
+        for (let index = 0; index < directories.length; index += 1) {
+          const [key, directory] = directories[index]
+          if (generation !== recovery.generation()) {
+            for (const [pendingKey, pendingDirectory] of directories.slice(index))
+              pendingDirectories.set(pendingKey, pendingDirectory)
+            break
+          }
+          await refreshDirectoryAsks(directory)
+          activeDirectories.delete(key)
+          if (generation === recovery.generation()) continue
+          for (const [pendingKey, pendingDirectory] of directories.slice(index))
+            pendingDirectories.set(pendingKey, pendingDirectory)
+          break
+        }
       }
     } finally {
-      activeDirectories = new Set()
+      activeDirectories = new Map()
+      permissionGeneration = undefined
     }
   }
 

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -3,11 +3,19 @@ import { createOpencodeClient as createControlClient } from "@opencode-ai/sdk/v2
 import { produce, type SetStoreFunction } from "solid-js/store"
 import { sleep, type EngineTarget } from "./connection"
 import { pushNotice } from "./events"
+import {
+  applySessionSnapshot,
+  applyTranscriptSnapshot,
+  createRecoveryCoordinator,
+  eventInDirectory,
+  type BufferedEvent,
+  type RecoveryCoordinator,
+} from "./recovery"
 import type { MessageEntry } from "./store"
 import {
+  dropSessionState,
   normalizeDir,
   putSession,
-  putSessions,
   recordLink,
   sessionBusy,
   spawnLink,
@@ -57,9 +65,11 @@ export function createActions(
   state: EngineState,
   set: SetStoreFunction<EngineState>,
   target: () => EngineTarget | undefined,
+  recovery: RecoveryCoordinator = createRecoveryCoordinator(() => undefined),
 ) {
   const pageSize = 100
   let allSessionsRequest: Promise<void> | undefined
+  const sessionRequests = new Map<string, Promise<boolean>>()
 
   function recordLinks(entries: { parts: { id: string }[] }[]) {
     for (const entry of entries) {
@@ -73,12 +83,24 @@ export function createActions(
   }
 
   async function reloadSession(id: string) {
+    const token = recovery.begin()
     const result = await requireClient().session.messages({ path: { id }, query: { limit: pageSize } })
-    const entries = [...(result.data ?? [])].sort((a, b) => a.info.id.localeCompare(b.info.id))
-    set("transcripts", id, entries)
-    set("loaded", id, true)
-    set("cursors", id, result.response?.headers?.get("x-next-cursor") ?? null)
-    recordLinks(entries)
+    const entries = [...requireSdkData(result, "Could not load the session transcript")].sort((a, b) =>
+      a.info.id.localeCompare(b.info.id),
+    )
+    let applied = false
+    const committed = recovery.commit(token, (events) => {
+      applied = applyTranscriptSnapshot(
+        state,
+        set,
+        id,
+        entries,
+        result.response?.headers?.get("x-next-cursor") ?? null,
+        events,
+      )
+    })
+    if (applied) recordLinks(entries)
+    return committed && applied
   }
 
   // Older pages come via the raw route because the generated SDK lacks the cursor param.
@@ -104,15 +126,41 @@ export function createActions(
     return sorted.length > 0
   }
 
-  async function openSession(id: string) {
-    if (state.loaded[id]) return
-    set("loaded", id, true)
-    await reloadSession(id)
+  function openSession(id: string) {
+    if (state.loaded[id]) return Promise.resolve(true)
+    const current = sessionRequests.get(id)
+    if (current) return current
+    const request = (async () => {
+      set("loading", id, true)
+      try {
+        return await reloadSession(id)
+      } catch (error) {
+        notice({
+          title: "Transcript load failed",
+          message: error instanceof Error ? error.message : "Could not load the session transcript",
+          variant: "error",
+        })
+        return false
+      } finally {
+        set(
+          produce((s) => {
+            delete s.loading[id]
+          }),
+        )
+      }
+    })()
+    sessionRequests.set(id, request)
+    void request.finally(() => sessionRequests.delete(id))
+    return request
   }
 
   async function loadSessions(directory: string) {
+    const token = recovery.begin()
     const result = await requireClient().session.list({ query: { directory } })
-    putSessions(set, result.data ?? [])
+    const sessions = requireSdkData(result, "Could not load sessions")
+    recovery.commit(token, (events) =>
+      applySessionSnapshot(set, sessions, (candidate) => normalizeDir(candidate) === normalizeDir(directory), events),
+    )
   }
 
   // One DB query for every workspace. Avoids booting an OpenCode instance per project.
@@ -121,6 +169,7 @@ export function createActions(
     if (!base) return
     if (allSessionsRequest) return allSessionsRequest
     allSessionsRequest = (async () => {
+      const token = recovery.begin()
       const query = new URLSearchParams({ archived: "true", limit: "10000" })
       const headers = {
         ...base.headers,
@@ -129,7 +178,8 @@ export function createActions(
       const response = await fetch(`${base.url}/experimental/session?${query}`, { headers }).catch(() => null)
       if (!response?.ok) return
       const sessions = (await response.json().catch(() => null)) as Session[] | null
-      putSessions(set, sessions ?? [])
+      if (!Array.isArray(sessions)) return
+      recovery.commit(token, (events) => applySessionSnapshot(set, sessions, () => true, events))
     })()
     try {
       await allSessionsRequest
@@ -441,9 +491,7 @@ export function createActions(
   function forgetSession(id: string) {
     set(
       produce((s) => {
-        delete s.sessions[id]
-        delete s.transcripts[id]
-        delete s.loaded[id]
+        dropSessionState(s, id)
       }),
     )
   }
@@ -451,95 +499,172 @@ export function createActions(
   // Replied ids are filtered out of poll snapshots that raced the reply.
   const answered = new Set<string>()
 
-  async function fetchJson<T>(path: string, dir: string): Promise<T | null> {
+  function askKey(kind: "permission" | "question", directory: string, id: string) {
+    return `${kind}\0${normalizeDir(directory)}\0${id}`
+  }
+
+  type FetchResult<T> = { ok: true; data: T } | { ok: false }
+
+  async function fetchJson<T>(path: string, dir: string): Promise<FetchResult<T>> {
     const base = target()
-    if (!base) return null
+    if (!base) return { ok: false }
     const joiner = path.includes("?") ? "&" : "?"
-    const response = await fetch(`${base.url}${path}${joiner}directory=${encodeURIComponent(dir)}`, {
-      headers: base.headers,
-    }).catch(() => null)
-    if (!response?.ok) return null
-    return (await response.json().catch(() => null)) as T | null
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 8000)
+    try {
+      const response = await fetch(`${base.url}${path}${joiner}directory=${encodeURIComponent(dir)}`, {
+        headers: base.headers,
+        signal: controller.signal,
+      }).catch(() => null)
+      if (!response?.ok) return { ok: false }
+      const data = (await response.json().catch(() => undefined)) as T | undefined
+      return data === undefined ? { ok: false } : { ok: true, data }
+    } finally {
+      clearTimeout(timer)
+    }
   }
 
   // The generated SDK lags the engine here; GET /permission and /question recover asks
   // raised while we weren't listening. Walk directories one at a time so idle workspaces
   // don't stampede instance boots on a timer.
-  async function refreshPermissions(directories: string[]) {
-    if (!target() || directories.length === 0) return
-    const results: {
-      permissions: Permission[]
-      questions: QuestionRequest[]
-    }[] = []
-    for (const dir of directories) {
-      const [permissions, questions] = await Promise.all([
-        fetchJson<PermissionRequest[]>("/permission", dir),
-        fetchJson<QuestionRequest[]>("/question", dir),
-      ])
-      results.push({
-        permissions: (permissions ?? []).map((request) => toPermission(request, dir)),
-        questions: (questions ?? []).map((request) => ({ ...request, directory: dir })),
-      })
+  const pendingDirectories = new Map<string, string>()
+  let activeDirectories = new Set<string>()
+  let permissionRequest: Promise<void> | undefined
+
+  function refreshPermissions(directories: string[]) {
+    if (!target()) return Promise.resolve()
+    for (const directory of directories) {
+      const key = normalizeDir(directory)
+      if (!key || activeDirectories.has(key)) continue
+      pendingDirectories.set(key, directory)
     }
-    const keep = new Set(directories.map(normalizeDir))
-    const reported = new Set(results.flatMap((r) => [...r.permissions, ...r.questions].map((item) => item.id)))
-    const previous = new Set<string>()
-    for (const list of Object.values(state.permissions)) {
-      for (const item of list) {
-        const dir = item.metadata?.directory
-        if (typeof dir === "string" && keep.has(normalizeDir(dir))) previous.add(item.id)
+    if (permissionRequest) return permissionRequest
+    permissionRequest = drainPermissions().finally(() => {
+      permissionRequest = undefined
+    })
+    return permissionRequest
+  }
+
+  async function drainPermissions() {
+    try {
+      while (pendingDirectories.size) {
+        const directories = [...pendingDirectories.entries()]
+        pendingDirectories.clear()
+        activeDirectories = new Set(directories.map(([key]) => key))
+        for (const [, directory] of directories) await refreshDirectoryAsks(directory)
       }
+    } finally {
+      activeDirectories = new Set()
     }
-    for (const list of Object.values(state.questions)) {
-      for (const item of list) {
-        if (item.directory && keep.has(normalizeDir(item.directory))) previous.add(item.id)
-      }
-    }
-    for (const id of previous) if (!reported.has(id)) answered.delete(id)
+  }
+
+  async function refreshDirectoryAsks(directory: string) {
+    const token = recovery.begin()
+    const [permissionResult, questionResult] = await Promise.all([
+      fetchJson<PermissionRequest[]>("/permission", directory),
+      fetchJson<QuestionRequest[]>("/question", directory),
+    ])
+    const permissions = permissionResult.ok && Array.isArray(permissionResult.data)
+      ? permissionResult.data.map((request) => toPermission(request, directory))
+      : undefined
+    const questions = questionResult.ok && Array.isArray(questionResult.data)
+      ? questionResult.data.map((request) => ({ ...request, directory }))
+      : undefined
+    if (!permissions && !questions) return
+    recovery.commit(token, (events) => reconcileAsks(directory, permissions, questions, events))
+  }
+
+  function reconcileAsks(
+    directory: string,
+    permissions: Permission[] | undefined,
+    questions: QuestionRequest[] | undefined,
+    events: BufferedEvent[],
+  ) {
+    const touchedPermissions = touchedAsks(events, directory, "permission")
+    const touchedQuestions = touchedAsks(events, directory, "question")
     set(
       produce((s) => {
-        for (const [sessionID, list] of Object.entries(s.permissions)) {
-          s.permissions[sessionID] = list.filter((item) => {
-            const dir = item.metadata?.directory
-            return typeof dir === "string" && !keep.has(normalizeDir(dir))
-          })
-          if (!s.permissions[sessionID]?.length) delete s.permissions[sessionID]
+        if (permissions) {
+          for (const [sessionID, list] of Object.entries(s.permissions)) {
+            s.permissions[sessionID] = list.filter((item) => {
+              const dir = item.metadata?.directory
+              return typeof dir !== "string" || normalizeDir(dir) !== normalizeDir(directory) || touchedPermissions.has(item.id)
+            })
+            if (!s.permissions[sessionID].length) delete s.permissions[sessionID]
+          }
+          for (const permission of permissions) {
+            if (answered.has(askKey("permission", directory, permission.id)) || touchedPermissions.has(permission.id))
+              continue
+            const list = (s.permissions[permission.sessionID] ??= [])
+            if (!list.some((item) => item.id === permission.id)) list.push(permission)
+          }
         }
-        for (const [sessionID, list] of Object.entries(s.questions)) {
-          s.questions[sessionID] = list.filter((item) => {
-            const dir = item.directory
-            return typeof dir === "string" && !keep.has(normalizeDir(dir))
-          })
-          if (!s.questions[sessionID]?.length) delete s.questions[sessionID]
-        }
-        for (const result of results) {
-          for (const permission of result.permissions)
-            if (!answered.has(permission.id)) (s.permissions[permission.sessionID] ??= []).push(permission)
-          for (const question of result.questions)
-            if (!answered.has(question.id)) (s.questions[question.sessionID] ??= []).push(question)
+        if (questions) {
+          for (const [sessionID, list] of Object.entries(s.questions)) {
+            s.questions[sessionID] = list.filter(
+              (item) => normalizeDir(item.directory ?? "") !== normalizeDir(directory) || touchedQuestions.has(item.id),
+            )
+            if (!s.questions[sessionID].length) delete s.questions[sessionID]
+          }
+          for (const question of questions) {
+            if (answered.has(askKey("question", directory, question.id)) || touchedQuestions.has(question.id)) continue
+            const list = (s.questions[question.sessionID] ??= [])
+            if (!list.some((item) => item.id === question.id)) list.push(question)
+          }
         }
       }),
     )
+    if (permissions) {
+      const reported = new Set(permissions.map((item) => askKey("permission", directory, item.id)))
+      const prefix = askKey("permission", directory, "")
+      for (const key of answered) if (key.startsWith(prefix) && !reported.has(key)) answered.delete(key)
+    }
+    if (questions) {
+      const reported = new Set(questions.map((item) => askKey("question", directory, item.id)))
+      const prefix = askKey("question", directory, "")
+      for (const key of answered) if (key.startsWith(prefix) && !reported.has(key)) answered.delete(key)
+    }
+  }
+
+  function touchedAsks(events: BufferedEvent[], directory: string, kind: "permission" | "question") {
+    const ids = new Set<string>()
+    for (const entry of events) {
+      const raw = entry.event as unknown as { type: string; properties?: Record<string, unknown> }
+      if (!raw.type.startsWith(`${kind}.`) || !eventInDirectory(entry, directory)) continue
+      const id = raw.properties?.id ?? raw.properties?.requestID ?? raw.properties?.permissionID
+      if (typeof id === "string") ids.add(id)
+    }
+    return ids
   }
 
   async function replyPermission(sessionID: string, permissionID: string, response: PermissionResponse) {
     const permission = (state.permissions[sessionID] ?? []).find((p) => p.id === permissionID)
     const dir = permission?.metadata?.directory as string | undefined
-    if (dir && normalizeDir(dir) !== normalizeDir(state.directory)) {
-      await replyElsewhere(sessionID, permissionID, response, dir)
-    } else {
-      const result = await requireClient().postSessionIdPermissionsPermissionId({
-        path: { id: sessionID, permissionID },
-        body: { response },
-      })
-      if (result.error) return
+    let ok = false
+    try {
+      if (dir && normalizeDir(dir) !== normalizeDir(state.directory)) {
+        ok = await replyElsewhere(sessionID, permissionID, response, dir)
+      } else {
+        const result = await requireClient().postSessionIdPermissionsPermissionId({
+          path: { id: sessionID, permissionID },
+          body: { response },
+        })
+        ok = result.data === true
+      }
+    } catch {
+      ok = false
     }
-    answered.add(permissionID)
+    if (!ok) {
+      notice({ title: "Permission reply failed", message: "The permission is still pending. Try again.", variant: "error" })
+      return false
+    }
+    answered.add(askKey("permission", dir ?? state.directory, permissionID))
     set(
       produce((s) => {
         s.permissions[sessionID] = (s.permissions[sessionID] ?? []).filter((p) => p.id !== permissionID)
       }),
     )
+    return true
   }
 
   async function answerQuestion(sessionID: string, requestID: string, answers: string[][] | null) {
@@ -555,7 +680,7 @@ export function createActions(
       body: JSON.stringify(answers ? { answers } : {}),
     }).catch(() => null)
     if (!response?.ok) return false
-    answered.add(requestID)
+    answered.add(askKey("question", dir, requestID))
     set(
       produce((s) => {
         s.questions[sessionID] = (s.questions[sessionID] ?? []).filter((item) => item.id !== requestID)
@@ -566,13 +691,14 @@ export function createActions(
 
   async function replyElsewhere(sessionID: string, permissionID: string, response: PermissionResponse, dir: string) {
     const base = target()
-    if (!base) return
+    if (!base) return false
     const url = `${base.url}/session/${sessionID}/permissions/${permissionID}?directory=${encodeURIComponent(dir)}`
-    await fetch(url, {
+    const result = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json", ...base.headers },
       body: JSON.stringify({ response }),
-    }).catch(() => {})
+    }).catch(() => null)
+    return result?.ok === true
   }
 
   async function interrupt(id: string) {
@@ -619,6 +745,7 @@ export function createActions(
 
   return {
     openSession,
+    reloadSession,
     loadOlder,
     loadSessions,
     loadAllSessions,

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -50,6 +50,19 @@ type PermissionRequest = {
   tool?: { messageID: string; callID: string }
 }
 
+// The engine caps an unspecified session-list limit at 100 rows, and the generated SDK's
+// query type has no limit field, so the ceiling has to be forced past the typed shape.
+export const sessionListLimit = 10000
+
+export function sessionListQuery(directory?: string) {
+  return { ...(directory === undefined ? {} : { directory }), limit: sessionListLimit } as { directory?: string }
+}
+
+// Proof of completeness, not a guess: a full page or a next cursor both mean rows were left behind.
+export function sessionListComplete(sessions: readonly unknown[], cursor?: string | null) {
+  return sessions.length < sessionListLimit && !cursor
+}
+
 function toPermission(request: PermissionRequest, directory: string): Permission {
   return {
     id: request.id,
@@ -96,6 +109,7 @@ export function createActions(
     id: string,
     token: ReturnType<RecoveryCoordinator["begin"]>,
     loadedAtStart: boolean,
+    lastAttempt: boolean,
   ) {
     try {
       const result = await requireClient().session.messages({
@@ -116,6 +130,7 @@ export function createActions(
           result.response?.headers?.get("x-next-cursor") ?? null,
           events,
           loadedAtStart,
+          lastAttempt,
         )
       })
       if (applied === "applied") recordLinks(entries)
@@ -126,11 +141,12 @@ export function createActions(
   }
 
   async function reloadSession(id: string) {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
+    const attempts = 3
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
       const loadedAtStart = state.loaded[id] === true
       const token = recovery.begin(transcriptEvents(id))
       try {
-        const result = await requestTranscript(id, token, loadedAtStart)
+        const result = await requestTranscript(id, token, loadedAtStart, attempt === attempts - 1)
         if (result === "applied") return true
         if (result !== "retry" || token.generation !== recovery.generation()) return false
       } catch (error) {
@@ -214,12 +230,13 @@ export function createActions(
   async function loadSessions(directory: string) {
     const token = recovery.begin(sessionEventsIn(directory))
     try {
-      const result = await requireClient().session.list({ query: { directory }, signal: token.signal })
+      const result = await requireClient().session.list({ query: sessionListQuery(directory), signal: token.signal })
       const sessions = requireSdkData(result, "Could not load sessions")
       recovery.commit(token, (events) =>
         applySessionSnapshot(
           set,
           sessions,
+          sessionListComplete(sessions),
           (candidate) => normalizeDir(candidate) === normalizeDir(directory),
           events,
           recovery.replay,
@@ -240,7 +257,7 @@ export function createActions(
     let entry: { token: typeof token; promise: Promise<void> }
     const request = (async () => {
       try {
-        const query = new URLSearchParams({ archived: "true", limit: "10000" })
+        const query = new URLSearchParams({ archived: "true", limit: String(sessionListLimit) })
         const headers = {
           ...base.headers,
           ...(state.directory ? { "x-opencode-directory": encodeURIComponent(state.directory) } : {}),
@@ -252,7 +269,10 @@ export function createActions(
         if (!response?.ok) return
         const sessions = (await response.json().catch(() => null)) as Session[] | null
         if (!Array.isArray(sessions)) return
-        recovery.commit(token, (events) => applySessionSnapshot(set, sessions, () => true, events, recovery.replay))
+        const complete = sessionListComplete(sessions, response.headers.get("x-next-cursor"))
+        recovery.commit(token, (events) =>
+          applySessionSnapshot(set, sessions, complete, () => true, events, recovery.replay),
+        )
       } finally {
         recovery.cancel(token)
       }

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -8,6 +8,9 @@ import {
   applyTranscriptSnapshot,
   createRecoveryCoordinator,
   eventInDirectory,
+  isSessionEvent,
+  isTranscriptEvent,
+  sessionID,
   type BufferedEvent,
   type RecoveryCoordinator,
 } from "./recovery"
@@ -68,8 +71,15 @@ export function createActions(
   recovery: RecoveryCoordinator = createRecoveryCoordinator(() => undefined),
 ) {
   const pageSize = 100
-  let allSessionsRequest: Promise<void> | undefined
-  const sessionRequests = new Map<string, Promise<boolean>>()
+  let allSessionsRequest: { token: ReturnType<RecoveryCoordinator["begin"]>; promise: Promise<void> } | undefined
+  const sessionRequests = new Map<
+    string,
+    { token: ReturnType<RecoveryCoordinator["begin"]>; promise: Promise<boolean> }
+  >()
+
+  const sessionEvents = (entry: BufferedEvent) => isSessionEvent(entry.event)
+  const transcriptEvents = (id: string) => (entry: BufferedEvent) =>
+    isTranscriptEvent(entry.event) && sessionID(entry.event) === id
 
   function recordLinks(entries: { parts: { id: string }[] }[]) {
     for (const entry of entries) {
@@ -82,109 +92,171 @@ export function createActions(
     }
   }
 
-  async function reloadSession(id: string) {
-    const token = recovery.begin()
-    const result = await requireClient().session.messages({ path: { id }, query: { limit: pageSize } })
-    const entries = [...requireSdkData(result, "Could not load the session transcript")].sort((a, b) =>
-      a.info.id.localeCompare(b.info.id),
-    )
-    let applied = false
-    const committed = recovery.commit(token, (events) => {
-      applied = applyTranscriptSnapshot(
-        state,
-        set,
-        id,
-        entries,
-        result.response?.headers?.get("x-next-cursor") ?? null,
-        events,
+  async function requestTranscript(id: string, token: ReturnType<RecoveryCoordinator["begin"]>) {
+    try {
+      const result = await requireClient().session.messages({
+        path: { id },
+        query: { limit: pageSize },
+        signal: token.signal,
+      })
+      const entries = [...requireSdkData(result, "Could not load the session transcript")].sort((a, b) =>
+        a.info.id.localeCompare(b.info.id),
       )
-    })
-    if (applied) recordLinks(entries)
-    return committed && applied
+      let applied = false
+      const committed = recovery.commit(token, (events) => {
+        applied = applyTranscriptSnapshot(
+          state,
+          set,
+          id,
+          entries,
+          result.response?.headers?.get("x-next-cursor") ?? null,
+          events,
+          recovery.replay,
+        )
+      })
+      if (applied) recordLinks(entries)
+      return committed && applied
+    } finally {
+      recovery.cancel(token)
+    }
+  }
+
+  async function reloadSession(id: string) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const token = recovery.begin(transcriptEvents(id))
+      try {
+        const loaded = await requestTranscript(id, token)
+        if (loaded || token.generation !== recovery.generation()) return loaded
+      } catch (error) {
+        if (token.generation !== recovery.generation() || !token.invalid || attempt > 0) throw error
+      }
+    }
+    return false
   }
 
   // Older pages come via the raw route because the generated SDK lacks the cursor param.
   async function loadOlder(id: string) {
     const cursor = state.cursors[id]
     const base = target()
-    if (!cursor || !base) return false
+    if (!cursor || !base || !state.sessions[id]) return false
+    const token = recovery.begin(transcriptEvents(id))
+    const directory = state.directory
     const url =
-      `${base.url}/session/${id}/message?directory=${encodeURIComponent(state.directory)}` +
+      `${base.url}/session/${id}/message?directory=${encodeURIComponent(directory)}` +
       `&limit=${pageSize}&before=${encodeURIComponent(cursor)}`
-    const response = await fetch(url, { headers: base.headers }).catch(() => null)
-    if (!response?.ok) return false
-    const older = ((await response.json().catch(() => [])) ?? []) as MessageEntry[]
-    const sorted = [...older].sort((a, b) => a.info.id.localeCompare(b.info.id))
-    set(
-      produce((s) => {
-        const existing = new Set((s.transcripts[id] ?? []).map((entry) => entry.info.id))
-        s.transcripts[id] = [...sorted.filter((entry) => !existing.has(entry.info.id)), ...(s.transcripts[id] ?? [])]
-      }),
-    )
-    set("cursors", id, response.headers.get("x-next-cursor"))
-    recordLinks(sorted)
-    return sorted.length > 0
+    try {
+      const response = await fetch(url, { headers: base.headers, signal: token.signal }).catch(() => null)
+      if (!response?.ok) return false
+      const older = ((await response.json().catch(() => [])) ?? []) as MessageEntry[]
+      const sorted = [...older].sort((a, b) => a.info.id.localeCompare(b.info.id))
+      let applied = false
+      const committed = recovery.commit(token, () => {
+        if (!state.sessions[id] || state.cursors[id] !== cursor || normalizeDir(state.directory) !== normalizeDir(directory))
+          return
+        set(
+          produce((s) => {
+            const existing = new Set((s.transcripts[id] ?? []).map((entry) => entry.info.id))
+            s.transcripts[id] = [...sorted.filter((entry) => !existing.has(entry.info.id)), ...(s.transcripts[id] ?? [])]
+            s.cursors[id] = response.headers.get("x-next-cursor")
+          }),
+        )
+        applied = true
+      })
+      if (applied) recordLinks(sorted)
+      return committed && applied && sorted.length > 0
+    } finally {
+      recovery.cancel(token)
+    }
   }
 
   function openSession(id: string) {
     if (state.loaded[id]) return Promise.resolve(true)
     const current = sessionRequests.get(id)
-    if (current) return current
+    if (current && recovery.current(current.token)) return current.promise
+    if (current) sessionRequests.delete(id)
+    const token = recovery.begin(transcriptEvents(id))
+    let entry: { token: typeof token; promise: Promise<boolean> } | undefined
     const request = (async () => {
       set("loading", id, true)
       try {
-        return await reloadSession(id)
+        return await requestTranscript(id, token)
       } catch (error) {
-        notice({
-          title: "Transcript load failed",
-          message: error instanceof Error ? error.message : "Could not load the session transcript",
-          variant: "error",
-        })
+        if (!token.signal.aborted)
+          notice({
+            title: "Transcript load failed",
+            message: error instanceof Error ? error.message : "Could not load the session transcript",
+            variant: "error",
+          })
         return false
       } finally {
-        set(
-          produce((s) => {
-            delete s.loading[id]
-          }),
-        )
+        if (entry && sessionRequests.get(id) === entry)
+          set(
+            produce((s) => {
+              delete s.loading[id]
+            }),
+          )
       }
     })()
-    sessionRequests.set(id, request)
-    void request.finally(() => sessionRequests.delete(id))
+    entry = { token, promise: request }
+    sessionRequests.set(id, entry)
+    void request.finally(() => {
+      if (entry && sessionRequests.get(id) === entry) sessionRequests.delete(id)
+    })
     return request
   }
 
   async function loadSessions(directory: string) {
-    const token = recovery.begin()
-    const result = await requireClient().session.list({ query: { directory } })
-    const sessions = requireSdkData(result, "Could not load sessions")
-    recovery.commit(token, (events) =>
-      applySessionSnapshot(set, sessions, (candidate) => normalizeDir(candidate) === normalizeDir(directory), events),
-    )
+    const token = recovery.begin(sessionEvents)
+    try {
+      const result = await requireClient().session.list({ query: { directory }, signal: token.signal })
+      const sessions = requireSdkData(result, "Could not load sessions")
+      recovery.commit(token, (events) =>
+        applySessionSnapshot(
+          set,
+          sessions,
+          (candidate) => normalizeDir(candidate) === normalizeDir(directory),
+          events,
+          recovery.replay,
+        ),
+      )
+    } finally {
+      recovery.cancel(token)
+    }
   }
 
   // One DB query for every workspace. Avoids booting an OpenCode instance per project.
   async function loadAllSessions() {
     const base = target()
     if (!base) return
-    if (allSessionsRequest) return allSessionsRequest
-    allSessionsRequest = (async () => {
-      const token = recovery.begin()
-      const query = new URLSearchParams({ archived: "true", limit: "10000" })
-      const headers = {
-        ...base.headers,
-        ...(state.directory ? { "x-opencode-directory": encodeURIComponent(state.directory) } : {}),
+    if (allSessionsRequest && recovery.current(allSessionsRequest.token)) return allSessionsRequest.promise
+    if (allSessionsRequest) allSessionsRequest = undefined
+    const token = recovery.begin(sessionEvents)
+    let entry: { token: typeof token; promise: Promise<void> }
+    const request = (async () => {
+      try {
+        const query = new URLSearchParams({ archived: "true", limit: "10000" })
+        const headers = {
+          ...base.headers,
+          ...(state.directory ? { "x-opencode-directory": encodeURIComponent(state.directory) } : {}),
+        }
+        const response = await fetch(`${base.url}/experimental/session?${query}`, {
+          headers,
+          signal: token.signal,
+        }).catch(() => null)
+        if (!response?.ok) return
+        const sessions = (await response.json().catch(() => null)) as Session[] | null
+        if (!Array.isArray(sessions)) return
+        recovery.commit(token, (events) => applySessionSnapshot(set, sessions, () => true, events, recovery.replay))
+      } finally {
+        recovery.cancel(token)
       }
-      const response = await fetch(`${base.url}/experimental/session?${query}`, { headers }).catch(() => null)
-      if (!response?.ok) return
-      const sessions = (await response.json().catch(() => null)) as Session[] | null
-      if (!Array.isArray(sessions)) return
-      recovery.commit(token, (events) => applySessionSnapshot(set, sessions, () => true, events))
     })()
+    entry = { token, promise: request }
+    allSessionsRequest = entry
     try {
-      await allSessionsRequest
+      await request
     } finally {
-      allSessionsRequest = undefined
+      if (allSessionsRequest === entry) allSessionsRequest = undefined
     }
   }
 
@@ -371,19 +443,31 @@ export function createActions(
   }
 
   async function refreshProviders() {
-    const result = await requireClient().provider.list().catch(() => null)
-    if (!result?.data) return null
-    set("providers", (result.data.all ?? []) as unknown as ProviderInfo[])
-    set("connected", result.data.connected ?? [])
-    set("defaultModels", result.data.default ?? {})
-    return result.data.connected ?? []
+    const token = recovery.begin(() => false)
+    try {
+      const result = await requireClient().provider.list({ signal: token.signal }).catch(() => null)
+      if (!result?.data) return null
+      const connected = result.data.connected ?? []
+      const committed = recovery.commit(token, () => {
+        set("providers", (result.data!.all ?? []) as unknown as ProviderInfo[])
+        set("connected", connected)
+        set("defaultModels", result.data!.default ?? {})
+      })
+      return committed ? connected : null
+    } finally {
+      recovery.cancel(token)
+    }
   }
 
   async function refreshAgents() {
-    const result = await requireClient().app.agents().catch(() => null)
-    if (!result?.data) return false
-    set("agents", result.data)
-    return true
+    const token = recovery.begin(() => false)
+    try {
+      const result = await requireClient().app.agents({ signal: token.signal }).catch(() => null)
+      if (!result?.data) return false
+      return recovery.commit(token, () => set("agents", result.data!))
+    } finally {
+      recovery.cancel(token)
+    }
   }
 
   function controlClient() {
@@ -505,23 +589,17 @@ export function createActions(
 
   type FetchResult<T> = { ok: true; data: T } | { ok: false }
 
-  async function fetchJson<T>(path: string, dir: string): Promise<FetchResult<T>> {
+  async function fetchJson<T>(path: string, dir: string, signal: AbortSignal): Promise<FetchResult<T>> {
     const base = target()
     if (!base) return { ok: false }
     const joiner = path.includes("?") ? "&" : "?"
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 8000)
-    try {
-      const response = await fetch(`${base.url}${path}${joiner}directory=${encodeURIComponent(dir)}`, {
-        headers: base.headers,
-        signal: controller.signal,
-      }).catch(() => null)
-      if (!response?.ok) return { ok: false }
-      const data = (await response.json().catch(() => undefined)) as T | undefined
-      return data === undefined ? { ok: false } : { ok: true, data }
-    } finally {
-      clearTimeout(timer)
-    }
+    const response = await fetch(`${base.url}${path}${joiner}directory=${encodeURIComponent(dir)}`, {
+      headers: base.headers,
+      signal,
+    }).catch(() => null)
+    if (!response?.ok) return { ok: false }
+    const data = (await response.json().catch(() => undefined)) as T | undefined
+    return data === undefined ? { ok: false } : { ok: true, data }
   }
 
   // The generated SDK lags the engine here; GET /permission and /question recover asks
@@ -559,19 +637,26 @@ export function createActions(
   }
 
   async function refreshDirectoryAsks(directory: string) {
-    const token = recovery.begin()
-    const [permissionResult, questionResult] = await Promise.all([
-      fetchJson<PermissionRequest[]>("/permission", directory),
-      fetchJson<QuestionRequest[]>("/question", directory),
-    ])
-    const permissions = permissionResult.ok && Array.isArray(permissionResult.data)
-      ? permissionResult.data.map((request) => toPermission(request, directory))
-      : undefined
-    const questions = questionResult.ok && Array.isArray(questionResult.data)
-      ? questionResult.data.map((request) => ({ ...request, directory }))
-      : undefined
-    if (!permissions && !questions) return
-    recovery.commit(token, (events) => reconcileAsks(directory, permissions, questions, events))
+    const token = recovery.begin((entry) => {
+      const type = (entry.event as { type: string }).type
+      return (type.startsWith("permission.") || type.startsWith("question.")) && eventInDirectory(entry, directory)
+    })
+    try {
+      const [permissionResult, questionResult] = await Promise.all([
+        fetchJson<PermissionRequest[]>("/permission", directory, token.signal),
+        fetchJson<QuestionRequest[]>("/question", directory, token.signal),
+      ])
+      const permissions = permissionResult.ok && Array.isArray(permissionResult.data)
+        ? permissionResult.data.map((request) => toPermission(request, directory))
+        : undefined
+      const questions = questionResult.ok && Array.isArray(questionResult.data)
+        ? questionResult.data.map((request) => ({ ...request, directory }))
+        : undefined
+      if (!permissions && !questions) return
+      recovery.commit(token, (events) => reconcileAsks(directory, permissions, questions, events))
+    } finally {
+      recovery.cancel(token)
+    }
   }
 
   function reconcileAsks(

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -3,7 +3,7 @@ import type { SetStoreFunction } from "solid-js/store"
 import { produce } from "solid-js/store"
 import { clearQuestionDraft } from "../state/question-drafts"
 import { errorText } from "./error"
-import { putSession, recordLink, spawnLink, type EngineState, type Notice, type QuestionRequest } from "./store"
+import { dropSessionState, putSession, recordLink, spawnLink, type EngineState, type Notice, type QuestionRequest } from "./store"
 
 type Set = SetStoreFunction<EngineState>
 
@@ -88,15 +88,7 @@ function upsertSession(set: Set, info: Session) {
 function dropSession(set: Set, info: Session) {
   set(
     produce((s) => {
-      delete s.sessions[info.id]
-      delete s.transcripts[info.id]
-      delete s.loaded[info.id]
-      delete s.permissions[info.id]
-      delete s.questions[info.id]
-      delete s.todos[info.id]
-      delete s.status[info.id]
-      delete s.activity[info.id]
-      delete s.errors[info.id]
+      dropSessionState(s, info.id)
     }),
   )
 }

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -4,7 +4,13 @@ import { produce } from "solid-js/store"
 import { createActions, type EngineActions } from "./actions"
 import { resolveEngine, sleep, type EngineTarget } from "./connection"
 import { reduce } from "./events"
-import { applySessionSnapshot, applyStatusSnapshot, createRecoveryCoordinator } from "./recovery"
+import {
+  applySessionSnapshot,
+  applyStatusSnapshot,
+  createRecoveryCoordinator,
+  isSessionEvent,
+  isStatusEvent,
+} from "./recovery"
 import { streamEvents } from "./sse"
 import { seedBench } from "./bench"
 import { createEngineState, normalizeDir, type EngineState, type ProviderInfo } from "./store"
@@ -37,21 +43,24 @@ export function EngineProvider(props: ParentProps) {
   async function hydrate() {
     const bootDirectory = directory ?? ""
     const api = requireClient()
-    const token = recovery.begin()
+    const token = recovery.begin((entry) => isSessionEvent(entry.event) || isStatusEvent(entry.event))
     try {
       const stale = Object.keys(state.loaded).filter((id) => state.loaded[id])
-      const [sessionsResult, statusesResult, providersResult, agentsResult, commandsResult] = await Promise.allSettled([
-        api.session.list(),
-        api.session.status(),
-        api.provider.list(),
-        api.app.agents(),
-        api.command.list(),
-      ])
+      const [sessionsResult, statusesResult, providersResult, agentsResult, commandsResult, healthResult] =
+        await Promise.allSettled([
+          api.session.list({ signal: token.signal }),
+          api.session.status({ signal: token.signal }),
+          api.provider.list({ signal: token.signal }),
+          api.app.agents({ signal: token.signal }),
+          api.command.list({ signal: token.signal }),
+          base ? loadHealth(base, token.signal) : Promise.resolve(null),
+        ])
       const sessions = settledData(sessionsResult)
       const statuses = settledData(statusesResult)
       const providers = settledData(providersResult)
       const agents = settledData(agentsResult)
       const commands = settledData(commandsResult)
+      const health = healthResult.status === "fulfilled" ? healthResult.value : null
       const committed = recovery.commit(token, (events) => {
         if (sessions)
           applySessionSnapshot(
@@ -59,6 +68,7 @@ export function EngineProvider(props: ParentProps) {
             sessions,
             (candidate) => normalizeDir(candidate) === normalizeDir(bootDirectory),
             events,
+            recovery.replay,
           )
         if (sessions && statuses) applyStatusSnapshot(set, sessions, statuses, events)
         if (providers) {
@@ -68,32 +78,34 @@ export function EngineProvider(props: ParentProps) {
         }
         if (agents) set("agents", agents)
         if (commands) set("commands", commands)
+        if (health?.version) set("version", health.version)
       })
       if (committed) await Promise.allSettled(stale.filter((id) => state.sessions[id]).map(actions.reloadSession))
-      if (!state.version && base) {
-        const health = await fetch(`${base.url}/global/health`, { headers: base.headers })
-          .then((response) => (response.ok ? (response.json() as Promise<{ version?: string }>) : null))
-          .catch(() => null)
-        if (health?.version) set("version", health.version)
-      }
     } finally {
       if (client === api && directory === bootDirectory && recovery.current(token))
         set("bootstrappedDirectory", bootDirectory)
+      recovery.cancel(token)
     }
   }
 
   async function pump(target: EngineTarget, signal: AbortSignal) {
     while (!signal.aborted) {
       try {
-        await streamEvents(target, signal, (event, eventDirectory) => {
-          if (event.type === "server.connected") {
-            recovery.advance()
-            set("connection", "online")
-            void hydrate().catch(() => undefined)
-            return
-          }
-          recovery.record(event, eventDirectory)
-        })
+        await streamEvents(
+          target,
+          signal,
+          (event, eventDirectory) => {
+            if (event.type === "server.connected") {
+              recovery.advance()
+              set("connection", "online")
+              void hydrate().catch(() => undefined)
+              return
+            }
+            recovery.record(event, eventDirectory)
+          },
+          undefined,
+          recovery.advance,
+        )
       } catch {}
       if (signal.aborted) return
       set("connection", "offline")
@@ -155,10 +167,15 @@ export function EngineProvider(props: ParentProps) {
   void resolveEngine()
     .then(async (target) => {
       base = target
-      const health = await fetch(`${target.url}/global/health`, { headers: target.headers })
-        .then((response) => (response.ok ? (response.json() as Promise<{ version?: string }>) : null))
-        .catch(() => null)
-      if (health?.version) set("version", health.version)
+      const token = recovery.begin(() => false)
+      try {
+        const health = await loadHealth(target, token.signal)
+        recovery.commit(token, () => {
+          if (health?.version) set("version", health.version)
+        })
+      } finally {
+        recovery.cancel(token)
+      }
       if (directory) startPump(directory)
     })
     .catch((error: unknown) => {
@@ -167,6 +184,7 @@ export function EngineProvider(props: ParentProps) {
     })
   onCleanup(() => {
     disposed = true
+    recovery.advance()
     pumpAbort?.abort()
   })
 
@@ -176,4 +194,10 @@ export function EngineProvider(props: ParentProps) {
 function settledData<T>(result: PromiseSettledResult<{ data?: T; error?: unknown }>): T | undefined {
   if (result.status === "rejected" || result.value.error !== undefined) return
   return result.value.data
+}
+
+async function loadHealth(target: EngineTarget, signal: AbortSignal) {
+  return fetch(`${target.url}/global/health`, { headers: target.headers, signal })
+    .then((response) => (response.ok ? (response.json() as Promise<{ version?: string }>) : null))
+    .catch(() => null)
 }

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -4,9 +4,10 @@ import { produce } from "solid-js/store"
 import { createActions, type EngineActions } from "./actions"
 import { resolveEngine, sleep, type EngineTarget } from "./connection"
 import { reduce } from "./events"
+import { applySessionSnapshot, applyStatusSnapshot, createRecoveryCoordinator } from "./recovery"
 import { streamEvents } from "./sse"
 import { seedBench } from "./bench"
-import { createEngineState, putSessions, type EngineState, type ProviderInfo } from "./store"
+import { createEngineState, normalizeDir, type EngineState, type ProviderInfo } from "./store"
 
 export type Engine = { state: EngineState; actions: EngineActions; setDirectory: (path: string | null) => void }
 
@@ -30,32 +31,45 @@ export function EngineProvider(props: ParentProps) {
     if (!client) throw new Error("engine offline")
     return client
   }
-  const actions = createActions(requireClient, state, set, () => base)
+  const recovery = createRecoveryCoordinator((event, eventDirectory) => reduce(set, event, eventDirectory))
+  const actions = createActions(requireClient, state, set, () => base, recovery)
 
   async function hydrate() {
     const bootDirectory = directory ?? ""
     const api = requireClient()
+    const token = recovery.begin()
     try {
-      const stale = Object.keys(state.loaded)
-      const [sessions, [statuses, providers, agents, commands]] = await Promise.all([
-        api.session.list().then((result) => {
-          putSessions(set, result.data ?? [])
-          return result
-        }),
-        Promise.all([api.session.status(), api.provider.list(), api.app.agents(), api.command.list()]),
+      const stale = Object.keys(state.loaded).filter((id) => state.loaded[id])
+      const [sessionsResult, statusesResult, providersResult, agentsResult, commandsResult] = await Promise.allSettled([
+        api.session.list(),
+        api.session.status(),
+        api.provider.list(),
+        api.app.agents(),
+        api.command.list(),
       ])
-      set(
-        produce((s) => {
-          const live = statuses.data ?? {}
-          for (const session of sessions.data ?? []) s.status[session.id] = live[session.id] ?? { type: "idle" }
-        }),
-      )
-      set("providers", (providers.data?.all ?? []) as unknown as ProviderInfo[])
-      set("connected", providers.data?.connected ?? [])
-      set("defaultModels", providers.data?.default ?? {})
-      set("agents", agents.data ?? [])
-      set("commands", commands.data ?? [])
-      await Promise.all(stale.map(reload))
+      const sessions = settledData(sessionsResult)
+      const statuses = settledData(statusesResult)
+      const providers = settledData(providersResult)
+      const agents = settledData(agentsResult)
+      const commands = settledData(commandsResult)
+      const committed = recovery.commit(token, (events) => {
+        if (sessions)
+          applySessionSnapshot(
+            set,
+            sessions,
+            (candidate) => normalizeDir(candidate) === normalizeDir(bootDirectory),
+            events,
+          )
+        if (sessions && statuses) applyStatusSnapshot(set, sessions, statuses, events)
+        if (providers) {
+          set("providers", (providers.all ?? []) as unknown as ProviderInfo[])
+          set("connected", providers.connected ?? [])
+          set("defaultModels", providers.default ?? {})
+        }
+        if (agents) set("agents", agents)
+        if (commands) set("commands", commands)
+      })
+      if (committed) await Promise.allSettled(stale.filter((id) => state.sessions[id]).map(actions.reloadSession))
       if (!state.version && base) {
         const health = await fetch(`${base.url}/global/health`, { headers: base.headers })
           .then((response) => (response.ok ? (response.json() as Promise<{ version?: string }>) : null))
@@ -63,17 +77,9 @@ export function EngineProvider(props: ParentProps) {
         if (health?.version) set("version", health.version)
       }
     } finally {
-      if (client === api && directory === bootDirectory) set("bootstrappedDirectory", bootDirectory)
+      if (client === api && directory === bootDirectory && recovery.current(token))
+        set("bootstrappedDirectory", bootDirectory)
     }
-  }
-
-  // ponytail: reconnect catch-up reloads the tail page only; deep scrollback refetches on demand
-  async function reload(id: string) {
-    const result = await requireClient().session.messages({ path: { id }, query: { limit: 100 } })
-    if (!result.data) return
-    const entries = [...result.data].sort((a, b) => a.info.id.localeCompare(b.info.id))
-    set("transcripts", id, entries)
-    set("cursors", id, result.response?.headers?.get("x-next-cursor") ?? null)
   }
 
   async function pump(target: EngineTarget, signal: AbortSignal) {
@@ -81,11 +87,12 @@ export function EngineProvider(props: ParentProps) {
       try {
         await streamEvents(target, signal, (event, eventDirectory) => {
           if (event.type === "server.connected") {
+            recovery.advance()
             set("connection", "online")
             void hydrate().catch(() => undefined)
             return
           }
-          reduce(set, event, eventDirectory)
+          recovery.record(event, eventDirectory)
         })
       } catch {}
       if (signal.aborted) return
@@ -99,6 +106,7 @@ export function EngineProvider(props: ParentProps) {
   // Session-keyed state and the global event stream survive directory switches. Only the
   // SDK client is re-pointed so workspace changes don't reconnect or wipe transcripts.
   function stopPump() {
+    recovery.advance()
     pumpAbort?.abort()
     pumpAbort = undefined
     client = undefined
@@ -138,6 +146,7 @@ export function EngineProvider(props: ParentProps) {
       startPump(path)
       return
     }
+    recovery.advance()
     client = createOpencodeClient({ baseUrl: base.url, headers: base.headers, directory: path })
     set("directory", path)
     if (state.connection === "online") void hydrate().catch(() => undefined)
@@ -162,4 +171,9 @@ export function EngineProvider(props: ParentProps) {
   })
 
   return <EngineContext.Provider value={{ state, actions, setDirectory }}>{props.children}</EngineContext.Provider>
+}
+
+function settledData<T>(result: PromiseSettledResult<{ data?: T; error?: unknown }>): T | undefined {
+  if (result.status === "rejected" || result.value.error !== undefined) return
+  return result.value.data
 }

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -8,6 +8,7 @@ import {
   applySessionSnapshot,
   applyStatusSnapshot,
   createRecoveryCoordinator,
+  eventInDirectory,
   isSessionEvent,
   isStatusEvent,
 } from "./recovery"
@@ -43,7 +44,9 @@ export function EngineProvider(props: ParentProps) {
   async function hydrate() {
     const bootDirectory = directory ?? ""
     const api = requireClient()
-    const token = recovery.begin((entry) => isSessionEvent(entry.event) || isStatusEvent(entry.event))
+    const token = recovery.begin(
+      (entry) => (isSessionEvent(entry.event) || isStatusEvent(entry.event)) && eventInDirectory(entry, bootDirectory),
+    )
     try {
       const stale = Object.keys(state.loaded).filter((id) => state.loaded[id])
       const [sessionsResult, statusesResult, providersResult, agentsResult, commandsResult, healthResult] =

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -1,7 +1,7 @@
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/client"
 import { createContext, onCleanup, useContext, type ParentProps } from "solid-js"
 import { produce } from "solid-js/store"
-import { createActions, type EngineActions } from "./actions"
+import { createActions, sessionListComplete, sessionListQuery, type EngineActions } from "./actions"
 import { resolveEngine, sleep, type EngineTarget } from "./connection"
 import { reduce } from "./events"
 import {
@@ -51,7 +51,7 @@ export function EngineProvider(props: ParentProps) {
       const stale = Object.keys(state.loaded).filter((id) => state.loaded[id])
       const [sessionsResult, statusesResult, providersResult, agentsResult, commandsResult, healthResult] =
         await Promise.allSettled([
-          api.session.list({ signal: token.signal }),
+          api.session.list({ query: sessionListQuery(), signal: token.signal }),
           api.session.status({ signal: token.signal }),
           api.provider.list({ signal: token.signal }),
           api.app.agents({ signal: token.signal }),
@@ -69,6 +69,7 @@ export function EngineProvider(props: ParentProps) {
           applySessionSnapshot(
             set,
             sessions,
+            sessionListComplete(sessions),
             (candidate) => normalizeDir(candidate) === normalizeDir(bootDirectory),
             events,
             recovery.replay,

--- a/src/engine/recovery.ts
+++ b/src/engine/recovery.ts
@@ -4,47 +4,101 @@ import { produce } from "solid-js/store"
 import { dropSessionState, normalizeDir, type EngineState, type MessageEntry } from "./store"
 
 export type BufferedEvent = { revision: number; event: Event; directory?: string }
-export type RecoveryToken = { generation: number; revision: number }
+export type RecoveryToken = {
+  generation: number
+  revision: number
+  signal: AbortSignal
+  readonly events: BufferedEvent[]
+  readonly filter: (entry: BufferedEvent) => boolean
+  controller: AbortController
+  timer?: ReturnType<typeof setTimeout>
+  active: boolean
+  invalid: boolean
+}
 
 export type RecoveryCoordinator = ReturnType<typeof createRecoveryCoordinator>
 
 export function createRecoveryCoordinator(
   reducer: (event: Event, directory?: string) => void,
-  maxBufferedEvents = 4096,
+  maxBufferedEvents = 512,
 ) {
   let generation = 0
   let revision = 0
-  let floor = 0
-  let events: BufferedEvent[] = []
+  const active = new Set<RecoveryToken>()
+
+  function finish(token: RecoveryToken) {
+    token.active = false
+    active.delete(token)
+    if (token.timer) clearTimeout(token.timer)
+  }
+
+  function current(token: RecoveryToken) {
+    return token.generation === generation && !token.invalid && !token.signal.aborted
+  }
 
   return {
     advance() {
       generation += 1
-      floor = revision
-      events = []
+      for (const token of active) {
+        token.invalid = true
+        token.controller.abort("recovery generation changed")
+        finish(token)
+      }
       return generation
     },
-    begin(): RecoveryToken {
-      return { generation, revision }
+    begin(filter: (entry: BufferedEvent) => boolean = () => true, timeoutMs = 10_000): RecoveryToken {
+      const controller = new AbortController()
+      const token: RecoveryToken = {
+        generation,
+        revision,
+        signal: controller.signal,
+        events: [],
+        filter,
+        controller,
+        active: true,
+        invalid: false,
+      }
+      token.timer = setTimeout(() => {
+        token.invalid = true
+        controller.abort("recovery request timed out")
+        finish(token)
+      }, timeoutMs)
+      active.add(token)
+      return token
     },
     revision() {
       return revision
     },
+    generation() {
+      return generation
+    },
     current(token: RecoveryToken) {
-      return token.generation === generation && token.revision >= floor
+      return current(token)
     },
     record(event: Event, directory?: string) {
       revision += 1
       reducer(event, directory)
-      events.push({ revision, event, directory })
-      if (events.length <= maxBufferedEvents) return
-      const removed = events.splice(0, events.length - maxBufferedEvents)
-      floor = removed.at(-1)?.revision ?? floor
+      const entry = { revision, event, directory }
+      for (const token of active) {
+        if (!token.filter(entry)) continue
+        token.events.push(entry)
+        if (token.events.length <= maxBufferedEvents) continue
+        token.invalid = true
+        token.controller.abort("recovery event buffer exceeded")
+        finish(token)
+      }
     },
     commit(token: RecoveryToken, apply: (events: BufferedEvent[]) => void) {
-      if (token.generation !== generation || token.revision < floor) return false
-      apply(events.filter((entry) => entry.revision > token.revision))
+      finish(token)
+      if (!current(token)) return false
+      apply(token.events)
       return true
+    },
+    cancel(token: RecoveryToken) {
+      finish(token)
+    },
+    replay(entries: BufferedEvent[]) {
+      for (const entry of entries) reducer(entry.event, entry.directory)
     },
   }
 }
@@ -85,8 +139,16 @@ export function applySessionSnapshot(
   sessions: EngineState["sessions"][string][],
   inScope: (directory: string) => boolean,
   events: BufferedEvent[],
+  replay: (events: BufferedEvent[]) => void = () => undefined,
 ) {
-  const touched = new Set(events.filter((entry) => isSessionEvent(entry.event)).map((entry) => sessionID(entry.event)))
+  const touched = new Set(
+    events
+      .filter(
+        (entry) =>
+          isSessionEvent(entry.event) && (entry.event as unknown as { type: string }).type !== "session.next.moved",
+      )
+      .map((entry) => sessionID(entry.event)),
+  )
   const reported = new Set(sessions.map((session) => session.id))
   set(
     produce((draft) => {
@@ -100,6 +162,7 @@ export function applySessionSnapshot(
       }
     }),
   )
+  replay(events.filter((entry) => (entry.event as unknown as { type: string }).type === "session.next.moved"))
 }
 
 export function applyStatusSnapshot(
@@ -125,17 +188,43 @@ export function applyTranscriptSnapshot(
   entries: MessageEntry[],
   cursor: string | null,
   events: BufferedEvent[],
+  replay: (events: BufferedEvent[]) => void = () => undefined,
 ) {
-  const changed = events.some((entry) => isTranscriptEvent(entry.event) && sessionID(entry.event) === id)
-  if (changed && state.loaded[id]) return false
+  if (
+    events.some(
+      (entry) => (entry.event as unknown as { type: string }).type === "session.deleted" && sessionID(entry.event) === id,
+    )
+  )
+    return false
+  const existing = state.loaded[id] ? (state.transcripts[id] ?? []) : []
+  const snapshotIDs = new Set(entries.map((entry) => entry.info.id))
+  const preservedIDs = new Set(existing.filter((entry) => !snapshotIDs.has(entry.info.id)).map((entry) => entry.info.id))
   set(
     produce((draft) => {
-      draft.transcripts[id] = entries
+      draft.transcripts[id] = [...existing.filter((entry) => preservedIDs.has(entry.info.id)), ...entries].sort((a, b) =>
+        a.info.id.localeCompare(b.info.id),
+      )
       draft.loaded[id] = true
       draft.cursors[id] = cursor
     }),
   )
+  replay(
+    events.filter((entry) => {
+      if (!isTranscriptEvent(entry.event) || sessionID(entry.event) !== id) return false
+      const message = messageID(entry.event)
+      return !message || !preservedIDs.has(message)
+    }),
+  )
   return true
+}
+
+function messageID(event: Event): string | undefined {
+  const properties = (event as unknown as { properties?: Record<string, unknown> }).properties ?? {}
+  if (typeof properties.messageID === "string") return properties.messageID
+  const info = properties.info as { id?: string } | undefined
+  if (typeof info?.id === "string") return info.id
+  const part = properties.part as { messageID?: string } | undefined
+  return part?.messageID
 }
 
 export function eventInDirectory(entry: BufferedEvent, directory: string) {

--- a/src/engine/recovery.ts
+++ b/src/engine/recovery.ts
@@ -141,6 +141,11 @@ export function applySessionSnapshot(
   events: BufferedEvent[],
   replay: (events: BufferedEvent[]) => void = () => undefined,
 ) {
+  const moved = new Set(
+    events
+      .filter((entry) => (entry.event as unknown as { type: string }).type === "session.next.moved")
+      .map((entry) => sessionID(entry.event)),
+  )
   const touched = new Set(
     events
       .filter(
@@ -153,7 +158,8 @@ export function applySessionSnapshot(
   set(
     produce((draft) => {
       for (const session of Object.values(draft.sessions)) {
-        if (!inScope(session.directory) || reported.has(session.id) || touched.has(session.id)) continue
+        if (!inScope(session.directory) || reported.has(session.id) || touched.has(session.id) || moved.has(session.id))
+          continue
         dropSessionState(draft, session.id)
       }
       for (const session of sessions) {
@@ -188,34 +194,78 @@ export function applyTranscriptSnapshot(
   entries: MessageEntry[],
   cursor: string | null,
   events: BufferedEvent[],
-  replay: (events: BufferedEvent[]) => void = () => undefined,
+  loadedAtStart = state.loaded[id] === true,
 ) {
-  if (
-    events.some(
-      (entry) => (entry.event as unknown as { type: string }).type === "session.deleted" && sessionID(entry.event) === id,
-    )
+  const relevant = events.filter((entry) => isTranscriptEvent(entry.event) && sessionID(entry.event) === id)
+  if (relevant.some((entry) => (entry.event as unknown as { type: string }).type === "session.deleted"))
+    return "deleted" as const
+  const existing = loadedAtStart ? (state.transcripts[id] ?? []) : []
+  const deltas = relevant.filter(
+    (entry) => (entry.event as unknown as { type: string }).type === "message.part.delta",
   )
-    return false
-  const existing = state.loaded[id] ? (state.transcripts[id] ?? []) : []
+  if (deltas.length && (!loadedAtStart || deltas.some((entry) => !deltaWasApplied(existing, entry.event))))
+    return "retry" as const
   const snapshotIDs = new Set(entries.map((entry) => entry.info.id))
-  const preservedIDs = new Set(existing.filter((entry) => !snapshotIDs.has(entry.info.id)).map((entry) => entry.info.id))
+  const touchedIDs = new Set(relevant.map((entry) => messageID(entry.event)).filter((value) => value !== undefined))
+  const preservedIDs = new Set(
+    existing
+      .filter((entry) => !snapshotIDs.has(entry.info.id) || touchedIDs.has(entry.info.id))
+      .map((entry) => entry.info.id),
+  )
   set(
     produce((draft) => {
-      draft.transcripts[id] = [...existing.filter((entry) => preservedIDs.has(entry.info.id)), ...entries].sort((a, b) =>
-        a.info.id.localeCompare(b.info.id),
-      )
+      draft.transcripts[id] = [
+        ...existing.filter((entry) => preservedIDs.has(entry.info.id)),
+        ...entries.filter((entry) => !preservedIDs.has(entry.info.id)),
+      ]
+      for (const entry of relevant) applyIdempotentTranscriptEvent(draft.transcripts[id], entry.event)
+      draft.transcripts[id].sort((a, b) => a.info.id.localeCompare(b.info.id))
       draft.loaded[id] = true
       draft.cursors[id] = cursor
     }),
   )
-  replay(
-    events.filter((entry) => {
-      if (!isTranscriptEvent(entry.event) || sessionID(entry.event) !== id) return false
-      const message = messageID(entry.event)
-      return !message || !preservedIDs.has(message)
-    }),
-  )
-  return true
+  return "applied" as const
+}
+
+function deltaWasApplied(entries: MessageEntry[], event: Event) {
+  const properties = (event as unknown as { properties: Record<string, unknown> }).properties
+  const messageID = properties.messageID
+  const partID = properties.partID
+  const field = properties.field
+  if (typeof messageID !== "string" || typeof partID !== "string" || typeof field !== "string") return false
+  const part = entries
+    .find((entry) => entry.info.id === messageID)
+    ?.parts.find((candidate) => candidate.id === partID) as unknown as Record<string, unknown> | undefined
+  return typeof part?.[field] === "string"
+}
+
+function applyIdempotentTranscriptEvent(entries: MessageEntry[], event: Event) {
+  const raw = event as unknown as { type: string; properties: Record<string, unknown> }
+  if (raw.type === "message.updated") {
+    const info = raw.properties.info as MessageEntry["info"]
+    const index = entries.findIndex((entry) => entry.info.id === info.id)
+    if (index >= 0) entries[index].info = info
+    else entries.push({ info, parts: [] })
+    return
+  }
+  if (raw.type === "message.removed") {
+    const index = entries.findIndex((entry) => entry.info.id === raw.properties.messageID)
+    if (index >= 0) entries.splice(index, 1)
+    return
+  }
+  if (raw.type === "message.part.updated") {
+    const part = raw.properties.part as MessageEntry["parts"][number]
+    const message = entries.find((entry) => entry.info.id === part.messageID)
+    if (!message) return
+    const index = message.parts.findIndex((candidate) => candidate.id === part.id)
+    if (index >= 0) message.parts[index] = part
+    else message.parts.push(part)
+    return
+  }
+  if (raw.type === "message.part.removed") {
+    const message = entries.find((entry) => entry.info.id === raw.properties.messageID)
+    if (message) message.parts = message.parts.filter((part) => part.id !== raw.properties.partID)
+  }
 }
 
 function messageID(event: Event): string | undefined {
@@ -228,5 +278,11 @@ function messageID(event: Event): string | undefined {
 }
 
 export function eventInDirectory(entry: BufferedEvent, directory: string) {
-  return typeof entry.directory === "string" && normalizeDir(entry.directory) === normalizeDir(directory)
+  const target = normalizeDir(directory)
+  if (typeof entry.directory === "string" && normalizeDir(entry.directory) === target) return true
+  const properties = (entry.event as unknown as { properties?: Record<string, unknown> }).properties ?? {}
+  const info = properties.info as { directory?: string } | undefined
+  if (typeof info?.directory === "string" && normalizeDir(info.directory) === target) return true
+  const location = properties.location as { directory?: string } | undefined
+  return typeof location?.directory === "string" && normalizeDir(location.directory) === target
 }

--- a/src/engine/recovery.ts
+++ b/src/engine/recovery.ts
@@ -1,0 +1,143 @@
+import type { Event } from "@opencode-ai/sdk/client"
+import type { SetStoreFunction } from "solid-js/store"
+import { produce } from "solid-js/store"
+import { dropSessionState, normalizeDir, type EngineState, type MessageEntry } from "./store"
+
+export type BufferedEvent = { revision: number; event: Event; directory?: string }
+export type RecoveryToken = { generation: number; revision: number }
+
+export type RecoveryCoordinator = ReturnType<typeof createRecoveryCoordinator>
+
+export function createRecoveryCoordinator(
+  reducer: (event: Event, directory?: string) => void,
+  maxBufferedEvents = 4096,
+) {
+  let generation = 0
+  let revision = 0
+  let floor = 0
+  let events: BufferedEvent[] = []
+
+  return {
+    advance() {
+      generation += 1
+      floor = revision
+      events = []
+      return generation
+    },
+    begin(): RecoveryToken {
+      return { generation, revision }
+    },
+    revision() {
+      return revision
+    },
+    current(token: RecoveryToken) {
+      return token.generation === generation && token.revision >= floor
+    },
+    record(event: Event, directory?: string) {
+      revision += 1
+      reducer(event, directory)
+      events.push({ revision, event, directory })
+      if (events.length <= maxBufferedEvents) return
+      const removed = events.splice(0, events.length - maxBufferedEvents)
+      floor = removed.at(-1)?.revision ?? floor
+    },
+    commit(token: RecoveryToken, apply: (events: BufferedEvent[]) => void) {
+      if (token.generation !== generation || token.revision < floor) return false
+      apply(events.filter((entry) => entry.revision > token.revision))
+      return true
+    },
+  }
+}
+
+export function sessionID(event: Event): string | undefined {
+  const raw = event as unknown as { type: string; properties?: Record<string, unknown> }
+  const properties = raw.properties ?? {}
+  if (typeof properties.sessionID === "string") return properties.sessionID
+  const info = properties.info as { id?: string; sessionID?: string } | undefined
+  if (raw.type.startsWith("session.")) return info?.id
+  if (typeof info?.sessionID === "string") return info.sessionID
+  const part = properties.part as { sessionID?: string } | undefined
+  return part?.sessionID
+}
+
+export function isSessionEvent(event: Event) {
+  const type = (event as { type: string }).type
+  return (
+    type === "session.created" ||
+    type === "session.updated" ||
+    type === "session.deleted" ||
+    type === "session.next.moved"
+  )
+}
+
+export function isStatusEvent(event: Event) {
+  const type = (event as { type: string }).type
+  return type === "session.status" || type === "session.idle" || type === "session.error" || type === "session.deleted"
+}
+
+export function isTranscriptEvent(event: Event) {
+  const type = (event as { type: string }).type
+  return type.startsWith("message.") || type === "session.deleted"
+}
+
+export function applySessionSnapshot(
+  set: SetStoreFunction<EngineState>,
+  sessions: EngineState["sessions"][string][],
+  inScope: (directory: string) => boolean,
+  events: BufferedEvent[],
+) {
+  const touched = new Set(events.filter((entry) => isSessionEvent(entry.event)).map((entry) => sessionID(entry.event)))
+  const reported = new Set(sessions.map((session) => session.id))
+  set(
+    produce((draft) => {
+      for (const session of Object.values(draft.sessions)) {
+        if (!inScope(session.directory) || reported.has(session.id) || touched.has(session.id)) continue
+        dropSessionState(draft, session.id)
+      }
+      for (const session of sessions) {
+        if (touched.has(session.id)) continue
+        draft.sessions[session.id] = { revert: undefined, share: undefined, ...session }
+      }
+    }),
+  )
+}
+
+export function applyStatusSnapshot(
+  set: SetStoreFunction<EngineState>,
+  sessions: EngineState["sessions"][string][],
+  statuses: EngineState["status"],
+  events: BufferedEvent[],
+) {
+  const touched = new Set(events.filter((entry) => isStatusEvent(entry.event)).map((entry) => sessionID(entry.event)))
+  set(
+    produce((draft) => {
+      for (const session of sessions) {
+        if (!touched.has(session.id)) draft.status[session.id] = statuses[session.id] ?? { type: "idle" }
+      }
+    }),
+  )
+}
+
+export function applyTranscriptSnapshot(
+  state: EngineState,
+  set: SetStoreFunction<EngineState>,
+  id: string,
+  entries: MessageEntry[],
+  cursor: string | null,
+  events: BufferedEvent[],
+) {
+  const changed = events.some((entry) => isTranscriptEvent(entry.event) && sessionID(entry.event) === id)
+  if (changed && state.loaded[id]) return false
+  set(
+    produce((draft) => {
+      draft.transcripts[id] = entries
+      draft.loaded[id] = true
+      draft.cursors[id] = cursor
+    }),
+  )
+  return true
+}
+
+export function eventInDirectory(entry: BufferedEvent, directory: string) {
+  return typeof entry.directory === "string" && normalizeDir(entry.directory) === normalizeDir(directory)
+}

--- a/src/engine/recovery.ts
+++ b/src/engine/recovery.ts
@@ -137,6 +137,9 @@ export function isTranscriptEvent(event: Event) {
 export function applySessionSnapshot(
   set: SetStoreFunction<EngineState>,
   sessions: EngineState["sessions"][string][],
+  // Absence only means "deleted" when the list is provably whole. A page the engine
+  // truncated would otherwise read as a mass deletion of everything past the cap.
+  complete: boolean,
   inScope: (directory: string) => boolean,
   events: BufferedEvent[],
   replay: (events: BufferedEvent[]) => void = () => undefined,
@@ -157,11 +160,12 @@ export function applySessionSnapshot(
   const reported = new Set(sessions.map((session) => session.id))
   set(
     produce((draft) => {
-      for (const session of Object.values(draft.sessions)) {
-        if (!inScope(session.directory) || reported.has(session.id) || touched.has(session.id) || moved.has(session.id))
-          continue
-        dropSessionState(draft, session.id)
-      }
+      if (complete)
+        for (const session of Object.values(draft.sessions)) {
+          if (!inScope(session.directory) || reported.has(session.id) || touched.has(session.id) || moved.has(session.id))
+            continue
+          dropSessionState(draft, session.id)
+        }
       for (const session of sessions) {
         if (touched.has(session.id)) continue
         draft.sessions[session.id] = { revert: undefined, share: undefined, ...session }
@@ -195,29 +199,32 @@ export function applyTranscriptSnapshot(
   cursor: string | null,
   events: BufferedEvent[],
   loadedAtStart = state.loaded[id] === true,
+  // Set on the caller's last attempt so an endlessly streaming session still lands.
+  lastAttempt = false,
 ) {
   const relevant = events.filter((entry) => isTranscriptEvent(entry.event) && sessionID(entry.event) === id)
   if (relevant.some((entry) => (entry.event as unknown as { type: string }).type === "session.deleted"))
     return "deleted" as const
   const existing = loadedAtStart ? (state.transcripts[id] ?? []) : []
-  const deltas = relevant.filter(
-    (entry) => (entry.event as unknown as { type: string }).type === "message.part.delta",
-  )
-  if (deltas.length && (!loadedAtStart || deltas.some((entry) => !deltaWasApplied(existing, entry.event))))
-    return "retry" as const
-  const snapshotIDs = new Set(entries.map((entry) => entry.info.id))
-  const touchedIDs = new Set(relevant.map((entry) => messageID(entry.event)).filter((value) => value !== undefined))
-  const preservedIDs = new Set(
-    existing
-      .filter((entry) => !snapshotIDs.has(entry.info.id) || touchedIDs.has(entry.info.id))
-      .map((entry) => entry.info.id),
-  )
+  // A delta is an append the snapshot may or may not already carry. Where live state
+  // holds one, that part stays live; where it does not, only a fresh read can resolve it.
+  const livePartKeys = new Set<string>()
+  let unresolvedDelta = false
+  for (const entry of relevant) {
+    if ((entry.event as unknown as { type: string }).type !== "message.part.delta") continue
+    const ref = deltaRef(entry.event)
+    if (ref && deltaWasApplied(existing, ref)) livePartKeys.add(partKey(ref.messageID, ref.partID))
+    else unresolvedDelta = true
+  }
+  // Once attempts run out, applying beats giving up: a tail that lags one delta heals on
+  // the next part update, while an unloaded transcript stays blank forever.
+  if (unresolvedDelta && !lastAttempt) return "retry" as const
+  const snapshot = new Map(entries.map((entry) => [entry.info.id, entry]))
+  const live = new Map(existing.map((entry) => [entry.info.id, entry]))
+  const order = [...snapshot.keys(), ...[...live.keys()].filter((key) => !snapshot.has(key))]
   set(
     produce((draft) => {
-      draft.transcripts[id] = [
-        ...existing.filter((entry) => preservedIDs.has(entry.info.id)),
-        ...entries.filter((entry) => !preservedIDs.has(entry.info.id)),
-      ]
+      draft.transcripts[id] = order.map((key) => mergeMessage(snapshot.get(key), live.get(key), livePartKeys))
       for (const entry of relevant) applyIdempotentTranscriptEvent(draft.transcripts[id], entry.event)
       draft.transcripts[id].sort((a, b) => a.info.id.localeCompare(b.info.id))
       draft.loaded[id] = true
@@ -227,16 +234,48 @@ export function applyTranscriptSnapshot(
   return "applied" as const
 }
 
-function deltaWasApplied(entries: MessageEntry[], event: Event) {
+// The snapshot and live state each hold parts the other missed, so reconcile per message
+// info and per part id. Letting either whole message win discards the other's parts.
+function mergeMessage(
+  snapshot: MessageEntry | undefined,
+  live: MessageEntry | undefined,
+  livePartKeys: Set<string>,
+): MessageEntry {
+  if (!snapshot) return live!
+  if (!live) return snapshot
+  const livePartsByID = new Map(live.parts.map((part) => [part.id, part]))
+  const snapshotPartIDs = new Set(snapshot.parts.map((part) => part.id))
+  return {
+    info: snapshot.info,
+    parts: [
+      ...snapshot.parts.map((part) =>
+        livePartKeys.has(partKey(snapshot.info.id, part.id)) ? (livePartsByID.get(part.id) ?? part) : part,
+      ),
+      ...live.parts.filter((part) => !snapshotPartIDs.has(part.id)),
+    ],
+  }
+}
+
+function partKey(messageID: string, partID: string) {
+  return `${messageID}\u0000${partID}`
+}
+
+type DeltaRef = { messageID: string; partID: string; field: string }
+
+function deltaRef(event: Event): DeltaRef | undefined {
   const properties = (event as unknown as { properties: Record<string, unknown> }).properties
   const messageID = properties.messageID
   const partID = properties.partID
   const field = properties.field
-  if (typeof messageID !== "string" || typeof partID !== "string" || typeof field !== "string") return false
+  if (typeof messageID !== "string" || typeof partID !== "string" || typeof field !== "string") return undefined
+  return { messageID, partID, field }
+}
+
+function deltaWasApplied(entries: MessageEntry[], ref: DeltaRef) {
   const part = entries
-    .find((entry) => entry.info.id === messageID)
-    ?.parts.find((candidate) => candidate.id === partID) as unknown as Record<string, unknown> | undefined
-  return typeof part?.[field] === "string"
+    .find((entry) => entry.info.id === ref.messageID)
+    ?.parts.find((candidate) => candidate.id === ref.partID) as unknown as Record<string, unknown> | undefined
+  return typeof part?.[ref.field] === "string"
 }
 
 function applyIdempotentTranscriptEvent(entries: MessageEntry[], event: Event) {
@@ -266,15 +305,6 @@ function applyIdempotentTranscriptEvent(entries: MessageEntry[], event: Event) {
     const message = entries.find((entry) => entry.info.id === raw.properties.messageID)
     if (message) message.parts = message.parts.filter((part) => part.id !== raw.properties.partID)
   }
-}
-
-function messageID(event: Event): string | undefined {
-  const properties = (event as unknown as { properties?: Record<string, unknown> }).properties ?? {}
-  if (typeof properties.messageID === "string") return properties.messageID
-  const info = properties.info as { id?: string } | undefined
-  if (typeof info?.id === "string") return info.id
-  const part = properties.part as { messageID?: string } | undefined
-  return part?.messageID
 }
 
 export function eventInDirectory(entry: BufferedEvent, directory: string) {

--- a/src/engine/sse.ts
+++ b/src/engine/sse.ts
@@ -1,26 +1,59 @@
 import type { Event } from "@opencode-ai/sdk/client"
 import type { EngineTarget } from "./connection"
 
+export const eventInactivityMs = 25_000
+
 export async function streamEvents(
   target: EngineTarget,
   signal: AbortSignal,
   onEvent: (event: Event, directory?: string) => void,
+  inactivityMs = eventInactivityMs,
 ) {
-  const res = await fetch(`${target.url}/global/event`, { headers: target.headers, signal })
-  if (!res.ok || !res.body) throw new Error(`event stream ${res.status}`)
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ""
-  for (;;) {
-    const chunk = await reader.read()
-    if (chunk.done) return
-    buffer += decoder.decode(chunk.value, { stream: true })
-    const lines = buffer.split("\n")
-    buffer = lines.pop() ?? ""
-    for (const line of lines) {
-      const event = parseLine(line)
-      if (event) onEvent(event.payload, event.directory)
+  const controller = new AbortController()
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let inactive = false
+  const cancelReader = () => void reader?.cancel().catch(() => undefined)
+  const abort = () => {
+    controller.abort(signal.reason)
+    cancelReader()
+  }
+  const armWatchdog = () => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      inactive = true
+      controller.abort("event stream inactive")
+      cancelReader()
+    }, inactivityMs)
+  }
+  signal.addEventListener("abort", abort, { once: true })
+  if (signal.aborted) abort()
+  armWatchdog()
+  try {
+    const res = await fetch(`${target.url}/global/event`, { headers: target.headers, signal: controller.signal })
+    if (!res.ok || !res.body) throw new Error(`event stream ${res.status}`)
+    reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+    for (;;) {
+      const chunk = await reader.read()
+      if (inactive) throw new Error("event stream inactive")
+      if (chunk.done) return
+      armWatchdog()
+      buffer += decoder.decode(chunk.value, { stream: true })
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        const event = parseLine(line)
+        if (event) onEvent(event.payload, event.directory)
+      }
     }
+  } finally {
+    if (timer) clearTimeout(timer)
+    signal.removeEventListener("abort", abort)
+    controller.abort()
+    await reader?.cancel().catch(() => undefined)
+    reader?.releaseLock()
   }
 }
 

--- a/src/engine/sse.ts
+++ b/src/engine/sse.ts
@@ -8,6 +8,7 @@ export async function streamEvents(
   signal: AbortSignal,
   onEvent: (event: Event, directory?: string) => void,
   inactivityMs = eventInactivityMs,
+  onExit: () => void = () => undefined,
 ) {
   const controller = new AbortController()
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
@@ -54,6 +55,7 @@ export async function streamEvents(
     controller.abort()
     await reader?.cancel().catch(() => undefined)
     reader?.releaseLock()
+    onExit()
   }
 }
 

--- a/src/engine/store.ts
+++ b/src/engine/store.ts
@@ -69,6 +69,7 @@ export type EngineState = {
   status: Record<string, SessionStatus>
   transcripts: Record<string, MessageEntry[]>
   loaded: Record<string, boolean>
+  loading: Record<string, boolean>
   permissions: Record<string, Permission[]>
   questions: Record<string, QuestionRequest[]>
   todos: Record<string, Todo[]>
@@ -114,6 +115,7 @@ export function createEngineState() {
     status: {},
     transcripts: {},
     loaded: {},
+    loading: {},
     permissions: {},
     questions: {},
     todos: {},
@@ -144,6 +146,20 @@ export function putSessions(set: SetStoreFunction<EngineState>, infos: Session[]
       for (const info of infos) sessions[info.id] = { revert: undefined, share: undefined, ...info }
     }),
   )
+}
+
+export function dropSessionState(state: EngineState, id: string) {
+  delete state.sessions[id]
+  delete state.transcripts[id]
+  delete state.loaded[id]
+  delete state.loading[id]
+  delete state.permissions[id]
+  delete state.questions[id]
+  delete state.todos[id]
+  delete state.status[id]
+  delete state.activity[id]
+  delete state.errors[id]
+  delete state.cursors[id]
 }
 
 export function modelInfo(state: EngineState, ref: ModelRef | null): ModelInfo | undefined {

--- a/tests/engine-recovery.test.ts
+++ b/tests/engine-recovery.test.ts
@@ -321,7 +321,7 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
   let transcriptApplied: ReturnType<typeof applyTranscriptSnapshot> | undefined
   expect(
     recovery.commit(token, (events) => {
-      applySessionSnapshot(set, [session("live", { title: "stale HTTP" })], () => true, events)
+      applySessionSnapshot(set, [session("live", { title: "stale HTTP" })], true, () => true, events)
       applyStatusSnapshot(set, [session("live")], { live: { type: "idle" } }, events)
       transcriptApplied = applyTranscriptSnapshot(
         state,
@@ -408,6 +408,138 @@ test("overlapping transcript snapshots preserve live deltas and apply activity s
   expect((state.transcripts.s1[1].parts[0] as { text: string }).text).toBe("tail!")
   expect(state.activity.s1.tools).toBe(2)
   expect(state.transcripts.s1[2].parts.map((part) => part.id)).toEqual(["tool-1", "tool-2"])
+})
+
+test("a workspace past the engine page default keeps every session it already had", async () => {
+  const [state, set] = createEngineState()
+  const all = Array.from({ length: 150 }, (_, index) => session(`s${String(index).padStart(3, "0")}`))
+  for (const info of all) set("sessions", info.id, info)
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  let requested: number | undefined
+  const actions = createActions(
+    () => ({
+      session: {
+        list: (options: { query?: { limit?: number } }) => {
+          requested = options.query?.limit
+          // The engine truncates to 100 rows when no limit is asked for.
+          return Promise.resolve({ data: all.slice(0, requested ?? 100) })
+        },
+      },
+    }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+    recovery,
+  )
+
+  await actions.loadSessions("C:/work")
+
+  expect(requested).toBeGreaterThan(all.length)
+  expect(Object.keys(state.sessions)).toHaveLength(all.length)
+})
+
+test("a truncated session page upserts without pruning the rows it left behind", async () => {
+  const [state, set] = createEngineState()
+  set("sessions", "older", session("older"))
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () =>
+    Response.json([session("newer")], { headers: { "x-next-cursor": "42" } })) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+      recovery,
+    )
+    await actions.loadAllSessions()
+
+    expect(state.sessions.newer.id).toBe("newer")
+    expect(state.sessions.older.id).toBe("older")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a live part update keeps the snapshot parts a disconnect missed on the same message", () => {
+  const [state, set] = createEngineState()
+  set("loaded", "s1", true)
+  set("transcripts", "s1", [
+    {
+      info: { id: "m1", sessionID: "s1", role: "assistant" },
+      parts: [{ id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "live" }],
+    },
+  ] as never)
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record({
+    type: "message.part.updated",
+    properties: { part: { id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "live update" } },
+  } as never)
+
+  recovery.commit(token, (events) =>
+    applyTranscriptSnapshot(
+      state,
+      set,
+      "s1",
+      [
+        {
+          info: { id: "m1", sessionID: "s1", role: "assistant" },
+          parts: [
+            { id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "stale" },
+            { id: "p2", sessionID: "s1", messageID: "m1", type: "text", text: "missed" },
+          ],
+        },
+      ] as never,
+      null,
+      events,
+    ),
+  )
+
+  const parts = state.transcripts.s1[0].parts as unknown as { id: string; text: string }[]
+  expect(parts.map((part) => part.id)).toEqual(["p1", "p2"])
+  expect(parts[0].text).toBe("live update")
+  expect(parts[1].text).toBe("missed")
+})
+
+test("a transcript that streams a delta on every attempt still ends up with content", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  let requests = 0
+  const actions = createActions(
+    () => ({
+      session: {
+        messages: () => {
+          requests += 1
+          recovery.record({
+            type: "message.part.delta",
+            properties: { sessionID: "s1", messageID: "m1", partID: "p1", field: "text", delta: "." },
+          } as never)
+          return Promise.resolve({
+            data: [
+              {
+                info: { id: "m1", sessionID: "s1", role: "assistant" },
+                parts: [{ id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "streaming" }],
+              },
+            ],
+            response: { headers: new Headers() },
+          })
+        },
+      },
+    }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+    recovery,
+  )
+
+  expect(await actions.openSession("s1")).toBeTrue()
+  expect(requests).toBe(3)
+  expect(state.loaded.s1).toBeTrue()
+  expect(state.loading.s1).toBeUndefined()
+  expect((state.transcripts.s1[0].parts[0] as { text: string }).text).toBe("streaming")
 })
 
 test("an initially unloaded transcript retries across non-idempotent stream deltas", async () => {
@@ -658,7 +790,7 @@ test("a moved event for an unknown session replays after the complete snapshot",
   expect(state.sessions.s1).toBeUndefined()
 
   recovery.commit(token, (events) =>
-    applySessionSnapshot(set, [session("s1")], () => true, events, recovery.replay),
+    applySessionSnapshot(set, [session("s1")], true, () => true, events, recovery.replay),
   )
 
   expect(state.sessions.s1.directory).toBe("C:/moved")
@@ -683,6 +815,7 @@ test("a known session moved into a queried directory survives a stale snapshot o
     applySessionSnapshot(
       set,
       [],
+      true,
       (directory) => directory === "C:/target",
       events,
       recovery.replay,
@@ -736,7 +869,7 @@ test("deleted-session events and workspace generations invalidate stale HTTP", (
   const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
   const deletion = recovery.begin()
   recovery.record({ type: "session.deleted", properties: { info: old } } as never, "C:/work")
-  recovery.commit(deletion, (events) => applySessionSnapshot(set, [old], () => true, events))
+  recovery.commit(deletion, (events) => applySessionSnapshot(set, [old], true, () => true, events))
   expect(state.sessions.old).toBeUndefined()
 
   const previousWorkspace = recovery.begin()

--- a/tests/engine-recovery.test.ts
+++ b/tests/engine-recovery.test.ts
@@ -292,6 +292,7 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
         ] as never,
         null,
         events,
+        recovery.replay,
       )
     }),
   ).toBeTrue()
@@ -300,7 +301,271 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
   expect(state.sessions.live.title).toBe("from SSE")
   expect(state.status.live.type).toBe("busy")
   expect((state.transcripts.live[0].parts[0] as { text: string }).text).toBe("from SSE")
-  expect(transcriptApplied).toBeFalse()
+  expect(transcriptApplied).toBeTrue()
+})
+
+test("transcript snapshots fill gaps without double-applying later tail deltas", () => {
+  const [state, set] = createEngineState()
+  set("loaded", "s1", true)
+  set("transcripts", "s1", [
+    {
+      info: { id: "m3", sessionID: "s1", role: "assistant" },
+      parts: [{ id: "p3", sessionID: "s1", messageID: "m3", type: "text", text: "tail" }],
+    },
+  ] as never)
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record(
+    {
+      type: "message.part.delta",
+      properties: { sessionID: "s1", messageID: "m3", partID: "p3", field: "text", delta: "!" },
+    } as never,
+  )
+
+  recovery.commit(token, (events) =>
+    applyTranscriptSnapshot(
+      state,
+      set,
+      "s1",
+      [
+        {
+          info: { id: "m2", sessionID: "s1", role: "user" },
+          parts: [{ id: "p2", sessionID: "s1", messageID: "m2", type: "text", text: "missed" }],
+        },
+      ] as never,
+      null,
+      events,
+      recovery.replay,
+    ),
+  )
+
+  expect(state.transcripts.s1.map((entry) => entry.info.id)).toEqual(["m2", "m3"])
+  expect((state.transcripts.s1[1].parts[0] as { text: string }).text).toBe("tail!")
+})
+
+test("an initially unloaded transcript replays stream events after its snapshot", () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record(
+    { type: "message.updated", properties: { info: { id: "m1", sessionID: "s1", role: "assistant" } } } as never,
+  )
+  recovery.record(
+    {
+      type: "message.part.updated",
+      properties: { part: { id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "live" } },
+    } as never,
+  )
+  recovery.record(
+    {
+      type: "message.part.delta",
+      properties: { sessionID: "s1", messageID: "m1", partID: "p1", field: "text", delta: " event" },
+    } as never,
+  )
+  expect(state.transcripts.s1).toBeUndefined()
+
+  recovery.commit(token, (events) =>
+    applyTranscriptSnapshot(state, set, "s1", [], null, events, recovery.replay),
+  )
+
+  expect(state.loaded.s1).toBeTrue()
+  expect((state.transcripts.s1[0].parts[0] as { text: string }).text).toBe("live event")
+})
+
+test("a reconnect does not coalesce transcript loads onto the aborted generation", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  let calls = 0
+  let firstSignal: AbortSignal | undefined
+  const actions = createActions(
+    () => ({
+      session: {
+        messages: (options: { signal: AbortSignal }) => {
+          calls += 1
+          if (calls === 1) {
+            firstSignal = options.signal
+            return new Promise((_, reject) =>
+              options.signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+                once: true,
+              }),
+            )
+          }
+          return Promise.resolve({
+            data: [{ info: { id: "fresh", sessionID: "s1", role: "user" }, parts: [] }],
+            response: { headers: new Headers() },
+          })
+        },
+      },
+    }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+    recovery,
+  )
+
+  const stale = actions.openSession("s1")
+  while (calls < 1) await Promise.resolve()
+  recovery.advance()
+  const fresh = actions.openSession("s1")
+
+  expect(fresh).not.toBe(stale)
+  expect(await stale).toBeFalse()
+  expect(await fresh).toBeTrue()
+  expect(firstSignal?.aborted).toBeTrue()
+  expect(calls).toBe(2)
+  expect(state.transcripts.s1[0].info.id).toBe("fresh")
+})
+
+test("a reconnect starts a new all-sessions request while the old request unwinds", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const originalFetch = globalThis.fetch
+  let calls = 0
+  let firstSignal: AbortSignal | undefined
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    calls += 1
+    if (calls === 1) {
+      firstSignal = init?.signal ?? undefined
+      return new Promise<Response>((resolve) =>
+        init?.signal?.addEventListener("abort", () => resolve(new Response(null, { status: 503 })), { once: true }),
+      )
+    }
+    return Response.json([session("fresh")])
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+      recovery,
+    )
+    const stale = actions.loadAllSessions()
+    while (calls < 1) await Promise.resolve()
+    recovery.advance()
+    const fresh = actions.loadAllSessions()
+    await Promise.all([stale, fresh])
+
+    expect(firstSignal?.aborted).toBeTrue()
+    expect(calls).toBe(2)
+    expect(state.sessions.fresh.id).toBe("fresh")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("unrelated event overflow cannot invalidate a scoped recovery request", () => {
+  const recovery = createRecoveryCoordinator(() => undefined, 1)
+  const token = recovery.begin(
+    (entry) => entry.event.type === "message.updated" && entry.event.properties.info.sessionID === "s1",
+  )
+  for (let index = 0; index < 100; index += 1)
+    recovery.record({ type: "session.status", properties: { sessionID: `other-${index}`, status: { type: "idle" } } } as never)
+
+  let committed = false
+  expect(recovery.commit(token, () => (committed = true))).toBeTrue()
+  expect(committed).toBeTrue()
+})
+
+test("pending older-page loads cannot recreate a deleted session", async () => {
+  const [state, set] = createEngineState()
+  const info = session("s1")
+  set("sessions", "s1", info)
+  set("loaded", "s1", true)
+  set("transcripts", "s1", [{ info: { id: "new", sessionID: "s1", role: "user" }, parts: [] }] as never)
+  set("cursors", "s1", "cursor")
+  set("directory", "C:/work")
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const response = deferred<Response>()
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (() => response.promise) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+      recovery,
+    )
+    const loading = actions.loadOlder("s1")
+    recovery.record({ type: "session.deleted", properties: { info } } as never, "C:/work")
+    response.resolve(
+      Response.json([{ info: { id: "old", sessionID: "s1", role: "user" }, parts: [] }], {
+        headers: { "x-next-cursor": "older" },
+      }),
+    )
+
+    expect(await loading).toBeFalse()
+    expect(state.sessions.s1).toBeUndefined()
+    expect(state.transcripts.s1).toBeUndefined()
+    expect(state.cursors.s1).toBeUndefined()
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a moved event for an unknown session replays after the complete snapshot", () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record(
+    {
+      type: "session.next.moved",
+      properties: {
+        sessionID: "s1",
+        projectID: "moved-project",
+        location: { directory: "C:/moved" },
+        timestamp: 42,
+      },
+    } as never,
+  )
+  expect(state.sessions.s1).toBeUndefined()
+
+  recovery.commit(token, (events) =>
+    applySessionSnapshot(set, [session("s1")], () => true, events, recovery.replay),
+  )
+
+  expect(state.sessions.s1.directory).toBe("C:/moved")
+  expect(state.sessions.s1.projectID).toBe("moved-project")
+  expect(state.sessions.s1.time.updated).toBe(42)
+})
+
+test("stream exit invalidates generation requests before returning", async () => {
+  const recovery = createRecoveryCoordinator(() => undefined)
+  const request = recovery.begin(() => false)
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async () =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close()
+        },
+      }),
+    )) as typeof fetch
+
+  try {
+    await streamEvents(
+      { url: "http://engine.test" },
+      new AbortController().signal,
+      () => undefined,
+      100,
+      recovery.advance,
+    )
+    expect(request.signal.aborted).toBeTrue()
+    expect(recovery.current(request)).toBeFalse()
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("generation request timeouts abort their REST signal", async () => {
+  const recovery = createRecoveryCoordinator(() => undefined)
+  const request = recovery.begin(() => false, 5)
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  expect(request.signal.aborted).toBeTrue()
+  expect(recovery.current(request)).toBeFalse()
 })
 
 test("deleted-session events and workspace generations invalidate stale HTTP", () => {
@@ -315,6 +580,7 @@ test("deleted-session events and workspace generations invalidate stale HTTP", (
 
   const previousWorkspace = recovery.begin()
   recovery.advance()
+  expect(previousWorkspace.signal.aborted).toBeTrue()
   expect(
     recovery.commit(previousWorkspace, () => {
       set("sessions", "stale", session("stale"))

--- a/tests/engine-recovery.test.ts
+++ b/tests/engine-recovery.test.ts
@@ -1,0 +1,362 @@
+import { expect, test } from "bun:test"
+import type { Event, Session } from "@opencode-ai/sdk/client"
+import { createActions } from "../src/engine/actions"
+import { reduce } from "../src/engine/events"
+import {
+  applySessionSnapshot,
+  applyStatusSnapshot,
+  applyTranscriptSnapshot,
+  createRecoveryCoordinator,
+} from "../src/engine/recovery"
+import { eventInactivityMs, streamEvents } from "../src/engine/sse"
+import { createEngineState } from "../src/engine/store"
+
+if (!("localStorage" in globalThis))
+  Object.defineProperty(globalThis, "localStorage", {
+    value: { getItem: () => null, setItem: () => undefined },
+  })
+
+function session(id: string, fields: Partial<Session> = {}): Session {
+  return {
+    id,
+    slug: id,
+    projectID: "project",
+    directory: "C:/work",
+    title: id,
+    version: "test",
+    time: { created: 1, updated: 1 },
+    ...fields,
+  } as Session
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+test("permission replies mutate only after confirmed success", async () => {
+  const [state, set] = createEngineState()
+  set("directory", "C:/active")
+  set("permissions", "s1", [
+    {
+      id: "cross",
+      sessionID: "s1",
+      type: "bash",
+      pattern: ["git status"],
+      messageID: "m1",
+      title: "Run command",
+      metadata: { directory: "C:/other" },
+      time: { created: 1 },
+    },
+  ] as never)
+  const originalFetch = globalThis.fetch
+  const responses: (Response | Error)[] = [new Error("offline"), new Response(null, { status: 500 }), new Response(null, { status: 204 })]
+  globalThis.fetch = (async () => {
+    const response = responses.shift()
+    if (response instanceof Error) throw response
+    return response!
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.replyPermission("s1", "cross", "once")).toBeFalse()
+    expect(await actions.replyPermission("s1", "cross", "once")).toBeFalse()
+    expect(state.permissions.s1.map((item) => item.id)).toEqual(["cross"])
+    expect(state.notices.filter((item) => item.title === "Permission reply failed")).toHaveLength(1)
+
+    expect(await actions.replyPermission("s1", "cross", "once")).toBeTrue()
+    expect(state.permissions.s1).toEqual([])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("active-workspace permission replies require a true SDK response", async () => {
+  const [state, set] = createEngineState()
+  set("directory", "C:/work")
+  set("permissions", "s1", [
+    {
+      id: "local",
+      sessionID: "s1",
+      type: "read",
+      messageID: "m1",
+      title: "Read file",
+      metadata: { directory: "C:/work" },
+      time: { created: 1 },
+    },
+  ] as never)
+  const replies = [{}, { data: true }]
+  const actions = createActions(
+    () => ({ postSessionIdPermissionsPermissionId: async () => replies.shift() }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+
+  expect(await actions.replyPermission("s1", "local", "once")).toBeFalse()
+  expect(state.permissions.s1).toHaveLength(1)
+  expect(await actions.replyPermission("s1", "local", "once")).toBeTrue()
+  expect(state.permissions.s1).toEqual([])
+})
+
+test("transcript loading retries failures, preserves data, and clears loading", async () => {
+  const [state, set] = createEngineState()
+  const existing = [{ info: { id: "old", sessionID: "s1", role: "user" }, parts: [] }]
+  const fresh = [{ info: { id: "new", sessionID: "s1", role: "user" }, parts: [] }]
+  set("transcripts", "s1", existing as never)
+  const pending = deferred<unknown>()
+  const replies = [
+    () => Promise.reject(new Error("network down")),
+    () => Promise.resolve({ error: { message: "engine unavailable" } }),
+    () => pending.promise,
+  ]
+  const actions = createActions(
+    () => ({ session: { messages: () => replies.shift()!() } }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+
+  expect(await actions.openSession("s1")).toBeFalse()
+  expect(state.loaded.s1).toBeUndefined()
+  expect(state.loading.s1).toBeUndefined()
+  expect(state.transcripts.s1).toEqual(existing)
+
+  expect(await actions.openSession("s1")).toBeFalse()
+  expect(state.loaded.s1).toBeUndefined()
+  expect(state.loading.s1).toBeUndefined()
+  expect(state.transcripts.s1).toEqual(existing)
+
+  const first = actions.openSession("s1")
+  const duplicate = actions.openSession("s1")
+  expect(duplicate).toBe(first)
+  expect(state.loading.s1).toBeTrue()
+  pending.resolve({ data: fresh, response: { headers: new Headers({ "x-next-cursor": "next" }) } })
+  expect(await first).toBeTrue()
+  expect(state.loading.s1).toBeUndefined()
+  expect(state.loaded.s1).toBeTrue()
+  expect(state.transcripts.s1).toEqual(fresh)
+  expect(state.cursors.s1).toBe("next")
+})
+
+test("ask polls distinguish endpoint failures from valid empty snapshots", async () => {
+  const [state, set] = createEngineState()
+  set("permissions", "s1", [
+    {
+      id: "p1",
+      sessionID: "s1",
+      type: "bash",
+      messageID: "m1",
+      title: "Run",
+      metadata: { directory: "C:/work" },
+      time: { created: 1 },
+    },
+  ] as never)
+  set("questions", "s1", [
+    { id: "q1", sessionID: "s1", questions: [], directory: "C:/work" },
+  ])
+  const originalFetch = globalThis.fetch
+  let round = 0
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const path = new URL(String(input)).pathname
+    if (round === 0) return path === "/permission" ? new Response(null, { status: 500 }) : Response.json([])
+    if (round === 1) return path === "/permission" ? new Response("not json") : new Response(null, { status: 503 })
+    return Response.json([])
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    await actions.refreshPermissions(["C:/work"])
+    expect(state.permissions.s1.map((item) => item.id)).toEqual(["p1"])
+    expect(state.questions.s1).toBeUndefined()
+
+    set("questions", "s1", [{ id: "q1", sessionID: "s1", questions: [], directory: "C:/work" }])
+    round = 1
+    await actions.refreshPermissions(["C:/work"])
+    expect(state.permissions.s1.map((item) => item.id)).toEqual(["p1"])
+    expect(state.questions.s1.map((item) => item.id)).toEqual(["q1"])
+
+    round = 2
+    await actions.refreshPermissions(["C:/work"])
+    expect(state.permissions.s1).toBeUndefined()
+    expect(state.questions.s1).toBeUndefined()
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a stale ask poll cannot erase asks received over SSE", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const permission = deferred<Response>()
+  const question = deferred<Response>()
+  const originalFetch = globalThis.fetch
+  let requests = 0
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    requests += 1
+    return new URL(String(input)).pathname === "/permission" ? permission.promise : question.promise
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+      recovery,
+    )
+    const poll = actions.refreshPermissions(["C:/work"])
+    while (requests < 2) await Promise.resolve()
+    recovery.record(
+      {
+        type: "permission.asked",
+        properties: { id: "p-new", sessionID: "s1", permission: "bash", metadata: {} },
+      } as never,
+      "C:/work",
+    )
+    recovery.record(
+      { type: "question.asked", properties: { id: "q-new", sessionID: "s1", questions: [] } } as never,
+      "C:/work",
+    )
+    permission.resolve(Response.json([]))
+    question.resolve(Response.json([]))
+    await poll
+
+    expect(state.permissions.s1.map((item) => item.id)).toEqual(["p-new"])
+    expect(state.questions.s1.map((item) => item.id)).toEqual(["q-new"])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("authoritative snapshots remove ghosts without overwriting newer SSE state", () => {
+  const [state, set] = createEngineState()
+  set("sessions", "live", session("live", { title: "before" }))
+  set("sessions", "ghost", session("ghost"))
+  set("status", "live", { type: "idle" })
+  set("loaded", "live", true)
+  set("transcripts", "live", [
+    {
+      info: { id: "m1", sessionID: "live", role: "assistant" },
+      parts: [{ id: "part", sessionID: "live", messageID: "m1", type: "text", text: "before" }],
+    },
+  ] as never)
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record(
+    { type: "session.updated", properties: { info: session("live", { title: "from SSE", time: { created: 1, updated: 3 } }) } } as never,
+    "C:/work",
+  )
+  recovery.record(
+    { type: "session.status", properties: { sessionID: "live", status: { type: "busy" } } } as never,
+    "C:/work",
+  )
+  recovery.record(
+    {
+      type: "message.part.updated",
+      properties: {
+        part: { id: "part", sessionID: "live", messageID: "m1", type: "text", text: "from SSE" },
+      },
+    } as never,
+    "C:/work",
+  )
+  let transcriptApplied = true
+  expect(
+    recovery.commit(token, (events) => {
+      applySessionSnapshot(set, [session("live", { title: "stale HTTP" })], () => true, events)
+      applyStatusSnapshot(set, [session("live")], { live: { type: "idle" } }, events)
+      transcriptApplied = applyTranscriptSnapshot(
+        state,
+        set,
+        "live",
+        [
+          {
+            info: { id: "m1", sessionID: "live", role: "assistant" },
+            parts: [{ id: "part", sessionID: "live", messageID: "m1", type: "text", text: "stale HTTP" }],
+          },
+        ] as never,
+        null,
+        events,
+      )
+    }),
+  ).toBeTrue()
+
+  expect(state.sessions.ghost).toBeUndefined()
+  expect(state.sessions.live.title).toBe("from SSE")
+  expect(state.status.live.type).toBe("busy")
+  expect((state.transcripts.live[0].parts[0] as { text: string }).text).toBe("from SSE")
+  expect(transcriptApplied).toBeFalse()
+})
+
+test("deleted-session events and workspace generations invalidate stale HTTP", () => {
+  const [state, set] = createEngineState()
+  const old = session("old")
+  set("sessions", "old", old)
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const deletion = recovery.begin()
+  recovery.record({ type: "session.deleted", properties: { info: old } } as never, "C:/work")
+  recovery.commit(deletion, (events) => applySessionSnapshot(set, [old], () => true, events))
+  expect(state.sessions.old).toBeUndefined()
+
+  const previousWorkspace = recovery.begin()
+  recovery.advance()
+  expect(
+    recovery.commit(previousWorkspace, () => {
+      set("sessions", "stale", session("stale"))
+    }),
+  ).toBeFalse()
+  expect(state.sessions.stale).toBeUndefined()
+})
+
+test("the SSE inactivity watchdog resets on heartbeats and cancels a silent reader", async () => {
+  expect(eventInactivityMs).toBeGreaterThan(10_000)
+  const originalFetch = globalThis.fetch
+  let canceled = false
+  let fetchAborted = false
+  const timers: ReturnType<typeof setTimeout>[] = []
+  const started = performance.now()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const heartbeat = new TextEncoder().encode('data: {"payload":{"type":"server.heartbeat","properties":{}}}\n\n')
+      timers.push(setTimeout(() => controller.enqueue(heartbeat), 5))
+      timers.push(setTimeout(() => controller.enqueue(heartbeat), 20))
+    },
+    cancel() {
+      canceled = true
+      for (const timer of timers) clearTimeout(timer)
+    },
+  })
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    init?.signal?.addEventListener("abort", () => (fetchAborted = true), { once: true })
+    return new Response(body)
+  }) as typeof fetch
+
+  try {
+    const events: Event[] = []
+    await expect(
+      streamEvents({ url: "http://engine.test" }, new AbortController().signal, (event) => events.push(event), 30),
+    ).rejects.toThrow("event stream inactive")
+    expect(performance.now() - started).toBeGreaterThanOrEqual(40)
+    expect(events).toEqual([])
+    expect(fetchAborted).toBeTrue()
+    expect(canceled).toBeTrue()
+  } finally {
+    for (const timer of timers) clearTimeout(timer)
+    globalThis.fetch = originalFetch
+  }
+})

--- a/tests/engine-recovery.test.ts
+++ b/tests/engine-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   applyStatusSnapshot,
   applyTranscriptSnapshot,
   createRecoveryCoordinator,
+  eventInDirectory,
 } from "../src/engine/recovery"
 import { eventInactivityMs, streamEvents } from "../src/engine/sse"
 import { createEngineState } from "../src/engine/store"
@@ -244,6 +245,48 @@ test("a stale ask poll cannot erase asks received over SSE", async () => {
   }
 })
 
+test("permission refreshes restart their full directory batch after a generation change", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const originalFetch = globalThis.fetch
+  const counts = new Map<string, number>()
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(String(input))
+    const key = `${url.pathname}|${url.searchParams.get("directory")}`
+    const count = (counts.get(key) ?? 0) + 1
+    counts.set(key, count)
+    if (url.searchParams.get("directory") !== "C:/one" || count > 1) return Promise.resolve(Response.json([]))
+    return new Promise<Response>((resolve) => {
+      const abort = () => resolve(new Response(null, { status: 503 }))
+      if (init?.signal?.aborted) abort()
+      else init?.signal?.addEventListener("abort", abort, { once: true })
+    })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+      recovery,
+    )
+    const refresh = actions.refreshPermissions(["C:/one", "C:/two"])
+    while ((counts.get("/permission|C:/one") ?? 0) < 1 || (counts.get("/question|C:/one") ?? 0) < 1)
+      await Promise.resolve()
+    recovery.advance()
+    const reconnectRefresh = actions.refreshPermissions(["C:/one"])
+    await Promise.all([refresh, reconnectRefresh])
+
+    expect(counts.get("/permission|C:/one")).toBe(2)
+    expect(counts.get("/question|C:/one")).toBe(2)
+    expect(counts.get("/permission|C:/two")).toBe(1)
+    expect(counts.get("/question|C:/two")).toBe(1)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
 test("authoritative snapshots remove ghosts without overwriting newer SSE state", () => {
   const [state, set] = createEngineState()
   set("sessions", "live", session("live", { title: "before" }))
@@ -275,7 +318,7 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
     } as never,
     "C:/work",
   )
-  let transcriptApplied = true
+  let transcriptApplied: ReturnType<typeof applyTranscriptSnapshot> | undefined
   expect(
     recovery.commit(token, (events) => {
       applySessionSnapshot(set, [session("live", { title: "stale HTTP" })], () => true, events)
@@ -292,7 +335,6 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
         ] as never,
         null,
         events,
-        recovery.replay,
       )
     }),
   ).toBeTrue()
@@ -301,10 +343,10 @@ test("authoritative snapshots remove ghosts without overwriting newer SSE state"
   expect(state.sessions.live.title).toBe("from SSE")
   expect(state.status.live.type).toBe("busy")
   expect((state.transcripts.live[0].parts[0] as { text: string }).text).toBe("from SSE")
-  expect(transcriptApplied).toBeTrue()
+  expect(transcriptApplied).toBe("applied")
 })
 
-test("transcript snapshots fill gaps without double-applying later tail deltas", () => {
+test("overlapping transcript snapshots preserve live deltas and apply activity side effects once", () => {
   const [state, set] = createEngineState()
   set("loaded", "s1", true)
   set("transcripts", "s1", [
@@ -321,6 +363,25 @@ test("transcript snapshots fill gaps without double-applying later tail deltas",
       properties: { sessionID: "s1", messageID: "m3", partID: "p3", field: "text", delta: "!" },
     } as never,
   )
+  for (const [id, tool] of [
+    ["tool-1", "read"],
+    ["tool-2", "bash"],
+  ]) {
+    recovery.record({
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id,
+          sessionID: "s1",
+          messageID: "m4",
+          type: "tool",
+          callID: id,
+          tool,
+          state: { status: "running", input: {}, time: { start: 1 } },
+        },
+      },
+    } as never)
+  }
 
   recovery.commit(token, (events) =>
     applyTranscriptSnapshot(
@@ -332,21 +393,53 @@ test("transcript snapshots fill gaps without double-applying later tail deltas",
           info: { id: "m2", sessionID: "s1", role: "user" },
           parts: [{ id: "p2", sessionID: "s1", messageID: "m2", type: "text", text: "missed" }],
         },
+        {
+          info: { id: "m3", sessionID: "s1", role: "assistant" },
+          parts: [{ id: "p3", sessionID: "s1", messageID: "m3", type: "text", text: "tail!" }],
+        },
+        { info: { id: "m4", sessionID: "s1", role: "assistant" }, parts: [] },
       ] as never,
       null,
       events,
-      recovery.replay,
     ),
   )
 
-  expect(state.transcripts.s1.map((entry) => entry.info.id)).toEqual(["m2", "m3"])
+  expect(state.transcripts.s1.map((entry) => entry.info.id)).toEqual(["m2", "m3", "m4"])
   expect((state.transcripts.s1[1].parts[0] as { text: string }).text).toBe("tail!")
+  expect(state.activity.s1.tools).toBe(2)
+  expect(state.transcripts.s1[2].parts.map((part) => part.id)).toEqual(["tool-1", "tool-2"])
 })
 
-test("an initially unloaded transcript replays stream events after its snapshot", () => {
+test("an initially unloaded transcript retries across non-idempotent stream deltas", async () => {
   const [state, set] = createEngineState()
   const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
-  const token = recovery.begin()
+  const first = deferred<unknown>()
+  let requests = 0
+  const actions = createActions(
+    () => ({
+      session: {
+        messages: () => {
+          requests += 1
+          if (requests === 1) return first.promise
+          return Promise.resolve({
+            data: [
+              {
+                info: { id: "m1", sessionID: "s1", role: "assistant" },
+                parts: [{ id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "live event" }],
+              },
+            ],
+            response: { headers: new Headers() },
+          })
+        },
+      },
+    }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+    recovery,
+  )
+  const loading = actions.openSession("s1")
+  while (requests < 1) await Promise.resolve()
   recovery.record(
     { type: "message.updated", properties: { info: { id: "m1", sessionID: "s1", role: "assistant" } } } as never,
   )
@@ -363,11 +456,18 @@ test("an initially unloaded transcript replays stream events after its snapshot"
     } as never,
   )
   expect(state.transcripts.s1).toBeUndefined()
+  first.resolve({
+    data: [
+      {
+        info: { id: "m1", sessionID: "s1", role: "assistant" },
+        parts: [{ id: "p1", sessionID: "s1", messageID: "m1", type: "text", text: "live event" }],
+      },
+    ],
+    response: { headers: new Headers() },
+  })
 
-  recovery.commit(token, (events) =>
-    applyTranscriptSnapshot(state, set, "s1", [], null, events, recovery.replay),
-  )
-
+  expect(await loading).toBeTrue()
+  expect(requests).toBe(2)
   expect(state.loaded.s1).toBeTrue()
   expect((state.transcripts.s1[0].parts[0] as { text: string }).text).toBe("live event")
 })
@@ -468,6 +568,40 @@ test("unrelated event overflow cannot invalidate a scoped recovery request", () 
   expect(committed).toBeTrue()
 })
 
+test("directory session loads ignore unrelated churn and include move source and destination", async () => {
+  const [state, set] = createEngineState()
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory), 1)
+  const result = deferred<unknown>()
+  const actions = createActions(
+    () => ({ session: { list: () => result.promise } }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+    recovery,
+  )
+  const loading = actions.loadSessions("C:/target")
+  for (let index = 0; index < 100; index += 1)
+    recovery.record(
+      { type: "session.updated", properties: { info: session(`other-${index}`, { directory: "C:/other" }) } } as never,
+      "C:/other",
+    )
+  result.resolve({ data: [session("target", { directory: "C:/target" })] })
+  await loading
+
+  const moved = {
+    revision: 1,
+    directory: "C:/source",
+    event: {
+      type: "session.next.moved",
+      properties: { sessionID: "target", location: { directory: "C:/target" }, timestamp: 2 },
+    } as Event,
+  }
+  expect(state.sessions.target.directory).toBe("C:/target")
+  expect(eventInDirectory(moved, "C:/source")).toBeTrue()
+  expect(eventInDirectory(moved, "C:/target")).toBeTrue()
+  expect(eventInDirectory(moved, "C:/other")).toBeFalse()
+})
+
 test("pending older-page loads cannot recreate a deleted session", async () => {
   const [state, set] = createEngineState()
   const info = session("s1")
@@ -529,6 +663,33 @@ test("a moved event for an unknown session replays after the complete snapshot",
 
   expect(state.sessions.s1.directory).toBe("C:/moved")
   expect(state.sessions.s1.projectID).toBe("moved-project")
+  expect(state.sessions.s1.time.updated).toBe(42)
+})
+
+test("a known session moved into a queried directory survives a stale snapshot omission", () => {
+  const [state, set] = createEngineState()
+  set("sessions", "s1", session("s1", { directory: "C:/source" }))
+  const recovery = createRecoveryCoordinator((event, directory) => reduce(set, event, directory))
+  const token = recovery.begin()
+  recovery.record(
+    {
+      type: "session.next.moved",
+      properties: { sessionID: "s1", location: { directory: "C:/target" }, timestamp: 42 },
+    } as never,
+    "C:/source",
+  )
+
+  recovery.commit(token, (events) =>
+    applySessionSnapshot(
+      set,
+      [],
+      (directory) => directory === "C:/target",
+      events,
+      recovery.replay,
+    ),
+  )
+
+  expect(state.sessions.s1.directory).toBe("C:/target")
   expect(state.sessions.s1.time.updated).toBe(42)
 })
 


### PR DESCRIPTION
## Summary
- preserve pending asks and transcript data across failed HTTP recovery requests
- reconcile complete reconnect snapshots without overwriting newer SSE or workspace generations
- reconnect silent event streams with an abortable heartbeat watchdog
- add deterministic coverage for permission, polling, hydration, transcript, and stream races

## Validation
- `bun test tests/engine-recovery.test.ts tests/startup.test.ts tests/activity.test.ts` (49 passed)
- `bun test --rerun-each 10 tests/engine-recovery.test.ts` (80 passed)
- `bun test tests` (126 passed)
- `bun run typecheck`
- `bun run build`
- `bun run test:engine`

Fixes #4
Fixes #8
Fixes #9
Fixes #13
Fixes #15