### PR TITLE
Fix session lifecycle recovery

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -24,9 +24,10 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
   gives the engine and Vite a random shared password.
 - Shell: `src-tauri/src/main.rs` locates the sidecar (next to the app exe, or
   `src-tauri/binaries` in dev), spawns `serve --hostname 127.0.0.1 --port 0` with a random
-  Basic-auth password, parses the printed URL, and serves both via `engine_status`. The child
-  is killed on exit. The frontend polls status until the sidecar is up, surfaces an
-  early process failure with its last stderr line, and times out after 45 seconds.
+  Basic-auth password, parses the printed URL, and serves both via `engine_status`. A bounded
+  supervisor restarts crashes with fresh credentials and backoff; crash-loop exhaustion is
+  surfaced with the last stderr line. Shutdown kills the child without restarting it, and the
+  frontend re-resolves the target after a live connection drops.
 - Packaging: `tauri build` produces an NSIS installer bundling the sidecar
   (`externalBin`) plus generated `drift-extensions/` beside the exe. Tauri builds
   clear the raw release resource directory before copying it so removed plugins

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -26,7 +26,9 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
   `src-tauri/binaries` in dev), spawns `serve --hostname 127.0.0.1 --port 0` with a random
   Basic-auth password, parses the printed URL, and serves both via `engine_status`. A bounded
   supervisor restarts crashes with fresh credentials and backoff; crash-loop exhaustion is
-  surfaced with the last stderr line. Shutdown kills the child without restarting it, and the
+  surfaced with the last stderr line. Child publication rechecks shutdown under the process
+  mutex, late children are killed immediately, and waits happen after releasing that mutex.
+  Shutdown kills the child without restarting it, and the
   frontend re-resolves the target after a live connection drops.
 - Packaging: `tauri build` produces an NSIS installer bundling the sidecar
   (`externalBin`) plus generated `drift-extensions/` beside the exe. Tauri builds
@@ -81,6 +83,7 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
 | File search | `GET /find/file` (fuzzy paths for composer @-mentions; mention parts use `file://` URLs + `source.text`, content read engine-side) |
 | Events | `GET /global/event` (SSE, all instances; frames are `{ directory, payload }`) |
 | Statuses | `GET /session/status` (per-instance map of non-idle sessions) |
+| Session relocation | `POST /experimental/control-plane/move-session`; a process-global session-ID gate serializes persisted-location validation and run admission with the move |
 
 ## Events reduced into the store
 
@@ -107,6 +110,9 @@ everything else is ignored on purpose.
   the error at the transcript bottom until the next prompt.
 - A session's active drain keeps its original model; steering a new prompt into a busy
   session does not switch models mid-drain.
+- Multi-session relocation is currently a validated sequential operation because upstream
+  exposes only a single-session move. On failure Drift checks every rollback response,
+  reloads all source and destination locations, and reports IDs that remain moved.
 - Model defaults from models.dev include non-chat models (video/image). Always filter on
   `capabilities.toolcall` before offering or auto-picking a model.
 - Pending permissions only arrive as `permission.updated` events, and only for the

--- a/docs/store.md
+++ b/docs/store.md
@@ -17,7 +17,7 @@ holds what Drift adds on top.
 | --- | --- | --- |
 | `workspace` | id, path (unique), name, icon, last_used, removed_at, purge_staged_at | workspaces = directories with display identity; purge staging keeps a removed path reserved until its exact session set is settled |
 | `session_meta` | session_id, workspace_id, archived_at | Drift metadata about engine sessions; today that is archive state |
-| `pending_session_delete` | session_id, directory, workspace_id, queued_at, claim | durable exact-ID engine deletion tombstones with opaque claims retained across startup, reconnect, and partial failure |
+| `pending_session_delete` | session_id, directory, workspace_id, queued_at, claim, claimed_at | durable exact-ID engine deletion tombstones with opaque claims retained across startup, reconnect, and partial failure |
 | `mcp_server` | name, config_json, updated_at | global Drift-owned definitions; full JSON preserves unknown fields |
 | `mcp_decision` | fingerprint, name, decision, decided_at | immutable global approval/rejection history by exact fingerprint |
 | `mcp_state` | id, generation, materialized_generation | CAS and generated-policy publication state |
@@ -34,10 +34,13 @@ preserving workspaces explicitly added through Drift, including empty ones.
 Archiving never deletes: `archived_at` is set and the thread disappears from the
 sidebar. On startup (once the engine is online) Drift purges archive rows older than
 7 days by first recording exact-ID deletion tombstones. A worker must revalidate the
-opaque claim, delete the exact ID, and observe that exact session as `404` before it can
-conditionally confirm the same claim. Transport, engine, and absence-check failures retry
-on the next online transition. Restoring metadata cancels its claim in the same transaction,
-and a stale snapshot cannot confirm a replacement claim. One archive drawer in the workspace
+opaque claim, rotate it into an exclusive in-flight claim, delete the exact ID, and observe
+that exact session as `404` before it can conditionally confirm the same claim. Failed attempts
+release with a new claim; abandoned claims reset on process startup. Restore and claim are
+serialized transactions, so restore either cancels pending work or is rejected while an in-flight
+deletion owns the session instead of racing it. A stale snapshot can neither delete restored data
+nor confirm a replacement
+claim. One archive drawer in the workspace
 header lists archived threads and
 soft-removed workspaces together; restoring a thread also restores its workspace when
 necessary.

--- a/docs/store.md
+++ b/docs/store.md
@@ -17,7 +17,7 @@ holds what Drift adds on top.
 | --- | --- | --- |
 | `workspace` | id, path (unique), name, icon, last_used, removed_at, purge_staged_at | workspaces = directories with display identity; purge staging keeps a removed path reserved until its exact session set is settled |
 | `session_meta` | session_id, workspace_id, archived_at | Drift metadata about engine sessions; today that is archive state |
-| `pending_session_delete` | session_id, directory, workspace_id, queued_at | durable exact-ID engine deletion tombstones retained across startup, reconnect, and partial failure |
+| `pending_session_delete` | session_id, directory, workspace_id, queued_at, claim | durable exact-ID engine deletion tombstones with opaque claims retained across startup, reconnect, and partial failure |
 | `mcp_server` | name, config_json, updated_at | global Drift-owned definitions; full JSON preserves unknown fields |
 | `mcp_decision` | fingerprint, name, decision, decided_at | immutable global approval/rejection history by exact fingerprint |
 | `mcp_state` | id, generation, materialized_generation | CAS and generated-policy publication state |
@@ -33,9 +33,12 @@ preserving workspaces explicitly added through Drift, including empty ones.
 
 Archiving never deletes: `archived_at` is set and the thread disappears from the
 sidebar. On startup (once the engine is online) Drift purges archive rows older than
-7 days by first recording exact-ID deletion tombstones. Successful deletions and `404`
-responses clear their tombstones; transport and engine failures retry on the next online
-transition. One archive drawer in the workspace header lists archived threads and
+7 days by first recording exact-ID deletion tombstones. A worker must revalidate the
+opaque claim, delete the exact ID, and observe that exact session as `404` before it can
+conditionally confirm the same claim. Transport, engine, and absence-check failures retry
+on the next online transition. Restoring metadata cancels its claim in the same transaction,
+and a stale snapshot cannot confirm a replacement claim. One archive drawer in the workspace
+header lists archived threads and
 soft-removed workspaces together; restoring a thread also restores its workspace when
 necessary.
 
@@ -43,10 +46,12 @@ necessary.
 
 Removing a workspace is a soft delete (`removed_at`); its sessions are left completely
 untouched (not archived, not deleted). Re-adding the same folder within 7 days restores
-the workspace row, custom name and icon included, and all its threads are simply there
+the workspace row, custom name and icon included, cancels its outstanding claims
+transactionally, and all its threads are simply there
 again. For workspaces removed more than 7 days ago, Drift snapshots the directory's exact
 session IDs and reserves the removed row while deleting them. New sessions created after
-path reuse are never selected by a path-wide delete, and restoring the reserved path
+path reuse are never selected by a path-wide delete. Session discovery paginates the
+global endpoint to exhaustion before staging, and restoring the reserved path
 cancels its workspace tombstones. The workspace row is hard-deleted only after every
 staged ID is confirmed absent.
 

--- a/docs/store.md
+++ b/docs/store.md
@@ -15,8 +15,9 @@ holds what Drift adds on top.
 
 | Table | Columns | Purpose |
 | --- | --- | --- |
-| `workspace` | id, path (unique), name, icon, last_used, removed_at | workspaces = directories with display identity; `icon` is empty (initials rendered from name) or a small data-URL image thumbnail |
+| `workspace` | id, path (unique), name, icon, last_used, removed_at, purge_staged_at | workspaces = directories with display identity; purge staging keeps a removed path reserved until its exact session set is settled |
 | `session_meta` | session_id, workspace_id, archived_at | Drift metadata about engine sessions; today that is archive state |
+| `pending_session_delete` | session_id, directory, workspace_id, queued_at | durable exact-ID engine deletion tombstones retained across startup, reconnect, and partial failure |
 | `mcp_server` | name, config_json, updated_at | global Drift-owned definitions; full JSON preserves unknown fields |
 | `mcp_decision` | fingerprint, name, decision, decided_at | immutable global approval/rejection history by exact fingerprint |
 | `mcp_state` | id, generation, materialized_generation | CAS and generated-policy publication state |
@@ -32,17 +33,22 @@ preserving workspaces explicitly added through Drift, including empty ones.
 
 Archiving never deletes: `archived_at` is set and the thread disappears from the
 sidebar. On startup (once the engine is online) Drift purges archive rows older than
-7 days and deletes those sessions from the engine. One archive drawer in the workspace
-header lists archived threads and soft-removed workspaces together; restoring a thread
-also restores its workspace when necessary.
+7 days by first recording exact-ID deletion tombstones. Successful deletions and `404`
+responses clear their tombstones; transport and engine failures retry on the next online
+transition. One archive drawer in the workspace header lists archived threads and
+soft-removed workspaces together; restoring a thread also restores its workspace when
+necessary.
 
 ## Workspace removal lifecycle
 
 Removing a workspace is a soft delete (`removed_at`); its sessions are left completely
 untouched (not archived, not deleted). Re-adding the same folder within 7 days restores
 the workspace row, custom name and icon included, and all its threads are simply there
-again. The startup purge hard-deletes workspace rows removed more than 7 days ago and
-deletes all engine sessions in those directories.
+again. For workspaces removed more than 7 days ago, Drift snapshots the directory's exact
+session IDs and reserves the removed row while deleting them. New sessions created after
+path reuse are never selected by a path-wide delete, and restoring the reserved path
+cancels its workspace tombstones. The workspace row is hard-deleted only after every
+staged ID is confirmed absent.
 
 ## Access
 

--- a/engine/overlays/session-pagination.patch
+++ b/engine/overlays/session-pagination.patch
@@ -1,0 +1,111 @@
+diff --git a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+--- a/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
++++ b/packages/opencode/src/server/routes/instance/httpapi/groups/experimental.ts
+@@ -82,6 +82,7 @@ export const SessionListQuery = Schema.Struct({
+   roots: Schema.optional(QueryBoolean),
+   start: Schema.optional(Schema.NumberFromString),
+   cursor: Schema.optional(Schema.NumberFromString),
++  cursorID: Schema.optional(SessionID),
+   search: Schema.optional(Schema.String),
+   limit: Schema.optional(Schema.NumberFromString),
+   archived: Schema.optional(QueryBoolean),
+diff --git a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
++++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+@@ -143,15 +143,19 @@ export const experimentalHandlers = HttpApiBuilder.group(RootHttpApi, "experime
+         roots: ctx.query.roots,
+         start: ctx.query.start,
+         cursor: ctx.query.cursor,
++        cursorID: ctx.query.cursorID,
+         search: ctx.query.search,
+         limit: limit + 1,
+         archived: ctx.query.archived,
+       })
+       const list = all.length > limit ? all.slice(0, limit) : all
++      const last = list[list.length - 1]
+       return HttpServerResponse.jsonUnsafe(list, {
+-        headers:
+-          all.length > limit && list.length > 0
+-            ? { "x-next-cursor": String(list[list.length - 1].time.updated) }
+-            : undefined,
++        headers: {
++          "access-control-expose-headers": "X-Next-Cursor, X-Next-Cursor-ID",
++          ...(all.length > limit && last
++            ? { "x-next-cursor": String(last.time.updated), "x-next-cursor-id": last.id }
++            : {}),
++        },
+       })
+     })
+diff --git a/packages/opencode/src/session/session.ts b/packages/opencode/src/session/session.ts
+--- a/packages/opencode/src/session/session.ts
++++ b/packages/opencode/src/session/session.ts
+@@ -315,6 +315,7 @@ export type GlobalListInput = {
+   roots?: boolean
+   start?: number
+   cursor?: number
++  cursorID?: SessionID
+   search?: string
+   limit?: number
+   archived?: boolean
+@@ -559,6 +560,14 @@ const layer: Layer.Layer<
+       if (input?.directory) conditions.push(eq(SessionTable.directory, input.directory))
+       if (input?.roots) conditions.push(isNull(SessionTable.parent_id))
+       if (input?.start) conditions.push(gte(SessionTable.time_updated, input.start))
+-      if (input?.cursor) conditions.push(lt(SessionTable.time_updated, input.cursor))
++      if (input?.cursor)
++        conditions.push(
++          input.cursorID
++            ? or(
++                lt(SessionTable.time_updated, input.cursor),
++                and(eq(SessionTable.time_updated, input.cursor), lt(SessionTable.id, input.cursorID)),
++              )!
++            : lt(SessionTable.time_updated, input.cursor),
++        )
+       if (input?.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
+       if (!input?.archived) conditions.push(isNull(SessionTable.time_archived))
+diff --git a/packages/opencode/test/server/httpapi-experimental.test.ts b/packages/opencode/test/server/httpapi-experimental.test.ts
+--- a/packages/opencode/test/server/httpapi-experimental.test.ts
++++ b/packages/opencode/test/server/httpapi-experimental.test.ts
+@@ -266,5 +266,41 @@ describe("experimental HttpApi", () => {
+       }),
+     { git: true, config: { formatter: false, lsp: false } },
+   )
+-
++
++  it.instance(
++    "paginates more than 100 sessions with equal update timestamps",
++    () =>
++      Effect.gen(function* () {
++        const tmp = yield* TestInstance
++        const expected: string[] = []
++        for (let index = 0; index < 105; index++) {
++          const item = yield* createSession({ title: `same-time-${index}` })
++          expected.push(item.id)
++          yield* setSessionUpdated(item, 1000)
++        }
++
++        const found: string[] = []
++        let cursor: string | undefined
++        let cursorID: string | undefined
++        for (;;) {
++          const query = new URLSearchParams({ directory: tmp.directory, limit: "100" })
++          if (cursor) query.set("cursor", cursor)
++          if (cursorID) query.set("cursorID", cursorID)
++          const page = yield* request(`${ExperimentalPaths.session}?${query}`, tmp.directory)
++          expect(page.status).toBe(200)
++          found.push(...(yield* json<Session.GlobalInfo[]>(page)).map((item) => item.id))
++          cursor = page.headers["x-next-cursor"]
++          cursorID = page.headers["x-next-cursor-id"]
++          if (!cursor) break
++          expect(cursor).toBe("1000")
++          expect(cursorID).toBeTruthy()
++        }
++
++        expect(found).toHaveLength(expected.length)
++        expect(new Set(found).size).toBe(expected.length)
++        expect(new Set(found)).toEqual(new Set(expected))
++      }),
++    { config: { formatter: false, lsp: false } },
++  )
++
+   testWorktreeMutations(

--- a/engine/overlays/session-run-guard.patch
+++ b/engine/overlays/session-run-guard.patch
@@ -1,5 +1,4 @@
 diff --git a/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts b/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
-index 4c13afd..5ce97ba 100644
 --- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
 +++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
 @@ -4,15 +4,18 @@ import { Effect } from "effect"
@@ -33,11 +32,14 @@ index 4c13afd..5ce97ba 100644
    if (error instanceof MoveSession.DestinationProjectMismatchError)
      return "Destination directory belongs to another project"
 diff --git a/packages/opencode/src/session/run-state.ts b/packages/opencode/src/session/run-state.ts
-index 5cefdd0..2db86e2 100644
 --- a/packages/opencode/src/session/run-state.ts
 +++ b/packages/opencode/src/session/run-state.ts
-@@ -3,13 +3,17 @@ import { InstanceState } from "@/effect/instance-state"
+@@ -1,15 +1,21 @@
+ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+ import { InstanceState } from "@/effect/instance-state"
  import { SessionV1 } from "@opencode-ai/core/v1/session"
++import { SessionV2 } from "@opencode-ai/core/session"
++import { SessionStore } from "@opencode-ai/core/session/store"
  import { Runner } from "@/effect/runner"
  import { BackgroundJob } from "@/background/job"
 -import { Effect, Latch, Layer, Scope, Context } from "effect"
@@ -55,89 +57,180 @@ index 5cefdd0..2db86e2 100644
    readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
    readonly ensureRunning: (
      sessionID: SessionID,
-@@ -36,6 +40,7 @@ const layer = Layer.effect(
-       Effect.fn("SessionRunState.state")(function* () {
-         const scope = yield* Scope.Scope
-         const runners = new Map<SessionID, Runner.Runner<SessionV1.WithParts>>()
-+        const locks = new Map<SessionID, Semaphore.Semaphore>()
-         yield* Effect.addFinalizer(
-           Effect.fnUntraced(function* () {
-             yield* Effect.forEach(runners.values(), (runner) => runner.cancel, {
-@@ -45,27 +50,49 @@ const layer = Layer.effect(
-             runners.clear()
-           }),
-         )
--        return { runners, scope }
-+        return { runners, locks, scope }
-       }),
-     )
+@@ -26,11 +32,51 @@ export interface Interface {
 
-+    const lock = (data: { locks: Map<SessionID, Semaphore.Semaphore> }, sessionID: SessionID) => {
-+      const existing = data.locks.get(sessionID)
-+      if (existing) return existing
-+      const next = Semaphore.makeUnsafe(1)
-+      data.locks.set(sessionID, next)
-+      return next
-+    }
+ export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRunState") {}
+
++export function makeAdmissionGate() {
++  const locks = new Map<SessionID, Semaphore.Semaphore>()
++  const active = new Map<SessionID, number>()
++  const lock = (sessionID: SessionID) => {
++    const existing = locks.get(sessionID)
++    if (existing) return existing
++    const next = Semaphore.makeUnsafe(1)
++    locks.set(sessionID, next)
++    return next
++  }
++  const run = <A, E, R>(sessionID: SessionID, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
++    Effect.acquireUseRelease(
++      lock(sessionID).withPermits(1)(
++        Effect.sync(() => active.set(sessionID, (active.get(sessionID) ?? 0) + 1)),
++      ),
++      () => effect,
++      () =>
++        lock(sessionID).withPermits(1)(
++          Effect.sync(() => {
++            const remaining = (active.get(sessionID) ?? 1) - 1
++            if (remaining > 0) active.set(sessionID, remaining)
++            else active.delete(sessionID)
++          }),
++        ),
++    )
++  const whileIdle = <A, E, R>(
++    sessionID: SessionID,
++    effect: Effect.Effect<A, E, R>,
++  ): Effect.Effect<A, E | Session.BusyError, R> =>
++    lock(sessionID).withPermits(1)(
++      Effect.gen(function* () {
++        if ((active.get(sessionID) ?? 0) > 0) return yield* busyError(sessionID)
++        return yield* effect
++      }),
++    )
++  return { run, whileIdle }
++}
 +
-     const runner = Effect.fn("SessionRunState.runner")(function* (
-       sessionID: SessionID,
-       onInterrupt: Effect.Effect<SessionV1.WithParts>,
-     ) {
+ const layer = Layer.effect(
+   Service,
+   Effect.gen(function* () {
+     const background = yield* BackgroundJob.Service
+     const status = yield* SessionStatus.Service
++    const sessions = yield* SessionStore.Service
++    const admission = makeAdmissionGate()
+
+     const state = yield* InstanceState.make(
+       Effect.fn("SessionRunState.state")(function* () {
+@@ -68,6 +114,10 @@ const layer = Layer.effect(
+       return next
+     })
+
++    const whileIdle: Interface["whileIdle"] = Effect.fn("SessionRunState.whileIdle")((sessionID, effect) =>
++      admission.whileIdle(sessionID, effect),
++    )
++
+     const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID) {
        const data = yield* InstanceState.get(state)
--      const existing = data.runners.get(sessionID)
--      if (existing) return existing
--      const next = Runner.make<SessionV1.WithParts>(data.scope, {
--        onIdle: Effect.gen(function* () {
--          data.runners.delete(sessionID)
--          yield* status.set(sessionID, { type: "idle" })
-+      return yield* lock(data, sessionID).withPermits(1)(
-+        Effect.sync(() => {
-+          const existing = data.runners.get(sessionID)
-+          if (existing) return existing
-+          const next = Runner.make<SessionV1.WithParts>(data.scope, {
-+            onIdle: Effect.gen(function* () {
-+              data.runners.delete(sessionID)
-+              yield* status.set(sessionID, { type: "idle" })
-+            }),
-+            onBusy: status.set(sessionID, { type: "busy" }),
-+            onInterrupt,
-+          })
-+          data.runners.set(sessionID, next)
-+          return next
-         }),
--        onBusy: status.set(sessionID, { type: "busy" }),
--        onInterrupt,
--      })
--      data.runners.set(sessionID, next)
--      return next
-+      )
-+    })
-+
-+    const whileIdle: Interface["whileIdle"] = Effect.fn("SessionRunState.whileIdle")(function* (sessionID, effect) {
-+      const data = yield* InstanceState.get(state)
-+      return yield* lock(data, sessionID).withPermits(1)(
+       const existing = data.runners.get(sessionID)
+@@ -90,7 +140,13 @@ const layer = Layer.effect(
+       onInterrupt: Effect.Effect<SessionV1.WithParts>,
+       work: Effect.Effect<SessionV1.WithParts>,
+     ) {
+-      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
++      return yield* admission.run(
++        sessionID,
 +        Effect.gen(function* () {
-+          if (data.runners.get(sessionID)?.busy) return yield* busyError(sessionID)
-+          return yield* effect
++          yield* assertPersistedLocation(sessionID)
++          return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
 +        }),
 +      )
      })
 
-     const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID) {
-@@ -104,7 +131,7 @@ const layer = Layer.effect(
-         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
+     const startShell = Effect.fn("SessionRunState.startShell")(function* (
+@@ -99,12 +155,25 @@ const layer = Layer.effect(
+       work: Effect.Effect<SessionV1.WithParts>,
+       ready?: Latch.Latch,
+     ) {
+-      return yield* (yield* runner(sessionID, onInterrupt))
+-        .startShell(work, ready)
+-        .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
++      return yield* admission.run(
++        sessionID,
++        Effect.gen(function* () {
++          yield* assertPersistedLocation(sessionID)
++          return yield* (yield* runner(sessionID, onInterrupt))
++            .startShell(work, ready)
++            .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
++        }),
++      )
      })
 
 -    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
++    const assertPersistedLocation = Effect.fn("SessionRunState.assertPersistedLocation")(function* (
++      sessionID: SessionID,
++    ) {
++      const current = yield* sessions.get(SessionV2.ID.make(sessionID))
++      if (!current || current.location.directory !== (yield* InstanceState.directory)) yield* busyError(sessionID)
++    })
++
 +    return Service.of({ assertNotBusy, whileIdle, cancel, ensureRunning, startShell })
    }),
  )
 
+@@ -146,6 +215,10 @@ function busyError(sessionID: SessionID) {
+   return new Session.BusyError({ sessionID })
+ }
+
+-export const node = LayerNode.make({ service: Service, layer: layer, deps: [BackgroundJob.node, SessionStatus.node] })
++export const node = LayerNode.make({
++  service: Service,
++  layer: layer,
++  deps: [BackgroundJob.node, SessionStatus.node, SessionStore.node],
++})
+
+ export * as SessionRunState from "./run-state"
+diff --git a/packages/opencode/src/session/session.ts b/packages/opencode/src/session/session.ts
+--- a/packages/opencode/src/session/session.ts
++++ b/packages/opencode/src/session/session.ts
+@@ -607,25 +607,21 @@ const layer: Layer.Layer<
+
+     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {
+       const session = yield* get(sessionID)
+-      try {
+-        // `remove` needs to work in all cases, such as broken sessions that
+-        // run cleanup without instance state.
+-        const hasInstance = yield* InstanceState.directory.pipe(
+-          Effect.as(true),
+-          Effect.catchCause(() => Effect.succeed(false)),
+-        )
+-
+-        if (hasInstance) yield* cancelBackgroundJobs(background, sessionID)
+-        const kids = yield* children(sessionID)
+-        for (const child of kids) {
+-          yield* remove(child.id)
+-        }
++      // `remove` needs to work in all cases, such as broken sessions that
++      // run cleanup without instance state.
++      const hasInstance = yield* InstanceState.directory.pipe(
++        Effect.as(true),
++        Effect.catchCause(() => Effect.succeed(false)),
++      )
+
+-        yield* events.publish(SessionV1.Event.Deleted, { sessionID, info: session })
+-        yield* events.remove(sessionID)
+-      } catch (error) {
+-        yield* Effect.logError("failed to remove session", { sessionID, error })
++      if (hasInstance) yield* cancelBackgroundJobs(background, sessionID)
++      const kids = yield* children(sessionID)
++      for (const child of kids) {
++        yield* remove(child.id)
+       }
++
++      yield* events.publish(SessionV1.Event.Deleted, { sessionID, info: session })
++      yield* events.remove(sessionID)
+     })
+
+     const updateMessage = <T extends SessionV1.Info>(msg: T): Effect.Effect<T> =>
 diff --git a/packages/opencode/test/server/httpapi-control-plane.test.ts b/packages/opencode/test/server/httpapi-control-plane.test.ts
-index b837bf7..c533deb 100644
 --- a/packages/opencode/test/server/httpapi-control-plane.test.ts
 +++ b/packages/opencode/test/server/httpapi-control-plane.test.ts
+@@ -1,6 +1,6 @@
+ import { NodeHttpServer } from "@effect/platform-node"
+-import { describe, expect } from "bun:test"
+-import { Context, Effect, Layer, Option, Ref } from "effect"
++import { describe, expect, test } from "bun:test"
++import { Context, Deferred, Effect, Exit, Fiber, Layer, Option, Ref } from "effect"
+ import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
+ import { HttpApiBuilder } from "effect/unstable/httpapi"
+ import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 @@ -10,6 +10,8 @@ import { Auth } from "../../src/auth"
  import { Config } from "../../src/config/config"
  import { Installation } from "../../src/installation"
@@ -183,7 +276,7 @@ index b837bf7..c533deb 100644
        const response = yield* HttpClientRequest.post("/experimental/control-plane/move-session").pipe(
          HttpClientRequest.setBody(HttpBody.jsonUnsafe(input)),
          HttpClient.execute,
-@@ -60,4 +77,19 @@ describe("control-plane HttpApi", () => {
+@@ -60,4 +77,44 @@ describe("control-plane HttpApi", () => {
        expect(yield* Ref.get(called)).toEqual(input)
      }),
    )
@@ -201,5 +294,30 @@ index b837bf7..c533deb 100644
 +      expect(yield* response.text).toContain("Session is still active")
 +      expect(yield* Ref.get(called)).toBeUndefined()
 +    }),
++  )
++})
++
++test("the process admission gate rejects a move until admitted work exits", async () => {
++  await Effect.runPromise(
++    Effect.scoped(
++      Effect.gen(function* () {
++        const gate = SessionRunState.makeAdmissionGate()
++        const started = yield* Deferred.make<void>()
++        const release = yield* Deferred.make<void>()
++        const run = yield* gate
++          .run(
++            input.sessionID,
++            Deferred.succeed(started, undefined).pipe(Effect.andThen(Deferred.await(release))),
++          )
++          .pipe(Effect.forkChild)
++        yield* Deferred.await(started)
++
++        const blocked = yield* Effect.exit(gate.whileIdle(input.sessionID, Effect.void))
++        expect(Exit.isFailure(blocked)).toBe(true)
++        yield* Deferred.succeed(release, undefined)
++        yield* Fiber.join(run)
++        expect(yield* gate.whileIdle(input.sessionID, Effect.succeed("moved"))).toBe("moved")
++      }),
++    ),
 +  )
  })

--- a/engine/overlays/session-run-guard.patch
+++ b/engine/overlays/session-run-guard.patch
@@ -1,0 +1,205 @@
+diff --git a/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts b/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
+index 4c13afd..5ce97ba 100644
+--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
++++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/control-plane.ts
+@@ -4,15 +4,18 @@ import { Effect } from "effect"
+ import { HttpApiBuilder } from "effect/unstable/httpapi"
+ import { RootHttpApi } from "../api"
+ import { ApiMoveSessionError, MoveSessionPayload } from "../groups/control-plane"
++import { Session } from "@/session/session"
++import { SessionRunState } from "@/session/run-state"
+
+ export const controlPlaneHandlers = HttpApiBuilder.group(RootHttpApi, "controlPlane", (handlers) =>
+   Effect.gen(function* () {
+     const service = yield* MoveSession.Service
++    const runState = yield* SessionRunState.Service
+
+     const moveSession = Effect.fn("ControlPlaneHttpApi.moveSession")(function* (ctx: {
+       payload: typeof MoveSessionPayload.Type
+     }) {
+-      yield* service.moveSession(ctx.payload).pipe(
++      yield* runState.whileIdle(ctx.payload.sessionID, service.moveSession(ctx.payload)).pipe(
+         Effect.mapError(
+           (error) =>
+             new ApiMoveSessionError({
+@@ -27,7 +30,8 @@ export const controlPlaneHandlers = HttpApiBuilder.group(RootHttpApi, "controlPl
+   }),
+ )
+
+-function message(error: MoveSession.Error) {
++function message(error: MoveSession.Error | Session.BusyError) {
++  if (error instanceof Session.BusyError) return "Session is still active"
+   if (error instanceof SessionV2.NotFoundError) return `Session not found: ${error.sessionID}`
+   if (error instanceof MoveSession.DestinationProjectMismatchError)
+     return "Destination directory belongs to another project"
+diff --git a/packages/opencode/src/session/run-state.ts b/packages/opencode/src/session/run-state.ts
+index 5cefdd0..2db86e2 100644
+--- a/packages/opencode/src/session/run-state.ts
++++ b/packages/opencode/src/session/run-state.ts
+@@ -3,13 +3,17 @@ import { InstanceState } from "@/effect/instance-state"
+ import { SessionV1 } from "@opencode-ai/core/v1/session"
+ import { Runner } from "@/effect/runner"
+ import { BackgroundJob } from "@/background/job"
+-import { Effect, Latch, Layer, Scope, Context } from "effect"
++import { Effect, Latch, Layer, Scope, Context, Semaphore } from "effect"
+ import { Session } from "./session"
+ import { SessionID } from "./schema"
+ import { SessionStatus } from "./status"
+
+ export interface Interface {
+   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
++  readonly whileIdle: <A, E, R>(
++    sessionID: SessionID,
++    effect: Effect.Effect<A, E, R>,
++  ) => Effect.Effect<A, E | Session.BusyError, R>
+   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+   readonly ensureRunning: (
+     sessionID: SessionID,
+@@ -36,6 +40,7 @@ const layer = Layer.effect(
+       Effect.fn("SessionRunState.state")(function* () {
+         const scope = yield* Scope.Scope
+         const runners = new Map<SessionID, Runner.Runner<SessionV1.WithParts>>()
++        const locks = new Map<SessionID, Semaphore.Semaphore>()
+         yield* Effect.addFinalizer(
+           Effect.fnUntraced(function* () {
+             yield* Effect.forEach(runners.values(), (runner) => runner.cancel, {
+@@ -45,27 +50,49 @@ const layer = Layer.effect(
+             runners.clear()
+           }),
+         )
+-        return { runners, scope }
++        return { runners, locks, scope }
+       }),
+     )
+
++    const lock = (data: { locks: Map<SessionID, Semaphore.Semaphore> }, sessionID: SessionID) => {
++      const existing = data.locks.get(sessionID)
++      if (existing) return existing
++      const next = Semaphore.makeUnsafe(1)
++      data.locks.set(sessionID, next)
++      return next
++    }
++
+     const runner = Effect.fn("SessionRunState.runner")(function* (
+       sessionID: SessionID,
+       onInterrupt: Effect.Effect<SessionV1.WithParts>,
+     ) {
+       const data = yield* InstanceState.get(state)
+-      const existing = data.runners.get(sessionID)
+-      if (existing) return existing
+-      const next = Runner.make<SessionV1.WithParts>(data.scope, {
+-        onIdle: Effect.gen(function* () {
+-          data.runners.delete(sessionID)
+-          yield* status.set(sessionID, { type: "idle" })
++      return yield* lock(data, sessionID).withPermits(1)(
++        Effect.sync(() => {
++          const existing = data.runners.get(sessionID)
++          if (existing) return existing
++          const next = Runner.make<SessionV1.WithParts>(data.scope, {
++            onIdle: Effect.gen(function* () {
++              data.runners.delete(sessionID)
++              yield* status.set(sessionID, { type: "idle" })
++            }),
++            onBusy: status.set(sessionID, { type: "busy" }),
++            onInterrupt,
++          })
++          data.runners.set(sessionID, next)
++          return next
+         }),
+-        onBusy: status.set(sessionID, { type: "busy" }),
+-        onInterrupt,
+-      })
+-      data.runners.set(sessionID, next)
+-      return next
++      )
++    })
++
++    const whileIdle: Interface["whileIdle"] = Effect.fn("SessionRunState.whileIdle")(function* (sessionID, effect) {
++      const data = yield* InstanceState.get(state)
++      return yield* lock(data, sessionID).withPermits(1)(
++        Effect.gen(function* () {
++          if (data.runners.get(sessionID)?.busy) return yield* busyError(sessionID)
++          return yield* effect
++        }),
++      )
+     })
+
+     const assertNotBusy = Effect.fn("SessionRunState.assertNotBusy")(function* (sessionID: SessionID) {
+@@ -104,7 +131,7 @@ const layer = Layer.effect(
+         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
+     })
+
+-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
++    return Service.of({ assertNotBusy, whileIdle, cancel, ensureRunning, startShell })
+   }),
+ )
+
+diff --git a/packages/opencode/test/server/httpapi-control-plane.test.ts b/packages/opencode/test/server/httpapi-control-plane.test.ts
+index b837bf7..c533deb 100644
+--- a/packages/opencode/test/server/httpapi-control-plane.test.ts
++++ b/packages/opencode/test/server/httpapi-control-plane.test.ts
+@@ -10,6 +10,8 @@ import { Auth } from "../../src/auth"
+ import { Config } from "../../src/config/config"
+ import { Installation } from "../../src/installation"
+ import { ServerAuth } from "../../src/server/auth"
++import { Session } from "../../src/session/session"
++import { SessionRunState } from "../../src/session/run-state"
+ import { RootHttpApi } from "../../src/server/routes/instance/httpapi/api"
+ import { controlHandlers } from "../../src/server/routes/instance/httpapi/handlers/control"
+ import { controlPlaneHandlers } from "../../src/server/routes/instance/httpapi/handlers/control-plane"
+@@ -24,6 +26,7 @@ const input = MoveSession.Input.make({
+   moveChanges: true,
+ })
+ const called = Ref.makeUnsafe<MoveSession.Input | undefined>(undefined)
++const busy = Ref.makeUnsafe(false)
+
+ const apiLayer = HttpRouter.serve(
+   HttpApiBuilder.layer(RootHttpApi).pipe(
+@@ -44,6 +47,18 @@ const apiLayer = HttpRouter.serve(
+       moveSession: (value) => Ref.set(called, value),
+     }),
+   ),
++  Layer.provide(
++    Layer.mock(SessionRunState.Service)({
++      assertNotBusy: () => Effect.void,
++      cancel: () => Effect.void,
++      ensureRunning: (_sessionID, _onInterrupt, work) => work,
++      startShell: (_sessionID, _onInterrupt, work) => work,
++      whileIdle: (sessionID, effect) =>
++        Ref.get(busy).pipe(
++          Effect.flatMap((active) => (active ? Effect.fail(new Session.BusyError({ sessionID })) : effect)),
++        ),
++    }),
++  ),
+   Layer.provide(ServerAuth.Config.configLayer({ password: Option.none(), username: "opencode" })),
+ )
+ const it = testEffect(apiLayer)
+@@ -51,6 +66,8 @@ const it = testEffect(apiLayer)
+ describe("control-plane HttpApi", () => {
+   it.live("moves a session through the root control-plane route", () =>
+     Effect.gen(function* () {
++      yield* Ref.set(busy, false)
++      yield* Ref.set(called, undefined)
+       const response = yield* HttpClientRequest.post("/experimental/control-plane/move-session").pipe(
+         HttpClientRequest.setBody(HttpBody.jsonUnsafe(input)),
+         HttpClient.execute,
+@@ -60,4 +77,19 @@ describe("control-plane HttpApi", () => {
+       expect(yield* Ref.get(called)).toEqual(input)
+     }),
+   )
++
++  it.live("rejects a move while the session is active", () =>
++    Effect.gen(function* () {
++      yield* Ref.set(busy, true)
++      yield* Ref.set(called, undefined)
++      const response = yield* HttpClientRequest.post("/experimental/control-plane/move-session").pipe(
++        HttpClientRequest.setBody(HttpBody.jsonUnsafe(input)),
++        HttpClient.execute,
++      )
++
++      expect(response.status).toBe(400)
++      expect(yield* response.text).toContain("Session is still active")
++      expect(yield* Ref.get(called)).toBeUndefined()
++    }),
++  )
+ })

--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -47,6 +47,11 @@ async function verifyAuthCapture() {
 await withEngineOverlays(async () => {
   await run("packages/core", ["test/move-session.test.ts"])
   await run("packages/opencode", ["test/server/httpapi-control-plane.test.ts"])
+  await run("packages/opencode", [
+    "test/server/httpapi-experimental.test.ts",
+    "-t",
+    "paginates more than 100 sessions with equal update timestamps",
+  ])
   await verifyAuthCapture()
   await run("packages/opencode", ["test/project/instance-bootstrap.test.ts", "-t", "InstanceStore|CLI bootstrap"])
   await run("packages/opencode", ["test/project/instance-bootstrap.test.ts", "-t", "Drift requires"])

--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -46,6 +46,7 @@ async function verifyAuthCapture() {
 
 await withEngineOverlays(async () => {
   await run("packages/core", ["test/move-session.test.ts"])
+  await run("packages/opencode", ["test/server/httpapi-control-plane.test.ts"])
   await verifyAuthCapture()
   await run("packages/opencode", ["test/project/instance-bootstrap.test.ts", "-t", "InstanceStore|CLI bootstrap"])
   await run("packages/opencode", ["test/project/instance-bootstrap.test.ts", "-t", "Drift requires"])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,29 +12,43 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
-use store::{ArchivedSession, Store, Workspace};
+use std::time::{Duration, Instant};
+use store::{ArchivedSession, DeletionSweep, PendingSessionDeletion, Store, Workspace};
 use tauri::{Emitter, Manager, RunEvent, State};
 use tauri_plugin_opener::OpenerExt;
 
 struct Engine {
-    url: Mutex<Option<String>>,
-    child: Mutex<Option<Child>>,
-    diagnostic: Mutex<String>,
-    password: String,
+    process: Mutex<EngineProcess>,
+    shutting_down: AtomicBool,
+    restart_requested: AtomicBool,
+}
+
+#[derive(Default)]
+struct EngineProcess {
+    url: Option<String>,
+    child: Option<Child>,
+    diagnostic: String,
+    password: Option<String>,
+    generation: u64,
+    terminal: bool,
 }
 
 impl Default for Engine {
     fn default() -> Self {
-        let mut bytes = [0u8; 32];
-        getrandom::fill(&mut bytes).expect("failed to generate engine password");
         Self {
-            url: Mutex::new(None),
-            child: Mutex::new(None),
-            diagnostic: Mutex::new(String::new()),
-            password: bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
+            process: Mutex::new(EngineProcess::default()),
+            shutting_down: AtomicBool::new(false),
+            restart_requested: AtomicBool::new(false),
         }
     }
+}
+
+fn engine_password() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("failed to generate engine password");
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 #[derive(Serialize)]
@@ -122,36 +136,17 @@ async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 fn engine_status(engine: State<Engine>) -> EngineStatus {
-    let url = engine.url.lock().unwrap().clone();
-    if url.is_some() {
+    let process = engine.process.lock().unwrap();
+    if process.url.is_some() {
         return EngineStatus {
-            url,
+            url: process.url.clone(),
             error: None,
-            password: Some(engine.password.clone()),
+            password: process.password.clone(),
         };
     }
-    let (has_child, status) = {
-        let mut child = engine.child.lock().unwrap();
-        (
-            child.is_some(),
-            child
-                .as_mut()
-                .and_then(|child| child.try_wait().ok().flatten()),
-        )
-    };
-    let diagnostic = engine.diagnostic.lock().unwrap();
-    let error = status
-        .map(|status| {
-            if diagnostic.is_empty() {
-                format!("embedded engine exited with {status}")
-            } else {
-                format!("embedded engine exited with {status}: {diagnostic}")
-            }
-        })
-        .or_else(|| (!has_child && !diagnostic.is_empty()).then(|| diagnostic.clone()));
     EngineStatus {
         url: None,
-        error,
+        error: process.terminal.then(|| process.diagnostic.clone()),
         password: None,
     }
 }
@@ -163,7 +158,9 @@ fn clipboard_write_text(window: tauri::WebviewWindow, text: String) -> Result<()
     use windows_sys::Win32::System::DataExchange::{
         CloseClipboard, EmptyClipboard, OpenClipboard, RegisterClipboardFormatW, SetClipboardData,
     };
-    use windows_sys::Win32::System::Memory::{GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE};
+    use windows_sys::Win32::System::Memory::{
+        GlobalAlloc, GlobalLock, GlobalUnlock, GMEM_MOVEABLE,
+    };
 
     if text.is_empty() {
         return Ok(());
@@ -433,9 +430,25 @@ fn store_remove_workspace(store: State<Store>, id: String) -> Result<(), String>
 }
 
 #[tauri::command]
-fn store_purge_removed_workspaces(store: State<Store>, before: i64) -> Result<Vec<String>, String> {
+fn store_prepare_deletions(store: State<Store>, before: i64) -> Result<DeletionSweep, String> {
+    store.prepare_deletions(before).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn store_stage_workspace_deletion(
+    store: State<Store>,
+    workspace_id: String,
+    session_ids: Vec<String>,
+) -> Result<Vec<PendingSessionDeletion>, String> {
     store
-        .purge_removed_workspaces(before)
+        .stage_workspace_deletion(&workspace_id, &session_ids)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn store_confirm_deletions(store: State<Store>, session_ids: Vec<String>) -> Result<(), String> {
+    store
+        .confirm_deletions(&session_ids)
         .map_err(|e| e.to_string())
 }
 
@@ -460,11 +473,6 @@ fn store_unarchive_session(store: State<Store>, session_id: String) -> Result<()
     store
         .unarchive_session(&session_id)
         .map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-fn store_purge_archived(store: State<Store>, before: i64) -> Result<Vec<String>, String> {
-    store.purge_archived(before).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -627,99 +635,198 @@ fn engine_extensions() -> Option<std::path::PathBuf> {
     source.exists().then_some(source)
 }
 
+const MAX_ENGINE_RESTARTS: u32 = 3;
+const ENGINE_STABLE_AFTER: Duration = Duration::from_secs(30);
+
+fn restart_delay(crashes: u32) -> Option<Duration> {
+    (crashes <= MAX_ENGINE_RESTARTS)
+        .then(|| Duration::from_millis(250 * 2u64.pow(crashes.saturating_sub(1))))
+}
+
+fn wait_for_restart(engine: &Engine, delay: Duration) -> bool {
+    let deadline = Instant::now() + delay;
+    while Instant::now() < deadline {
+        if engine.shutting_down.load(Ordering::SeqCst) {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    true
+}
+
 fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBuf) {
     std::thread::spawn(move || {
         let Some(binary) = engine_binary() else {
-            *app.state::<Engine>().diagnostic.lock().unwrap() =
-                "embedded engine binary not found".into();
+            let engine = app.state::<Engine>();
+            let mut process = engine.process.lock().unwrap();
+            process.diagnostic = "embedded engine binary not found".into();
+            process.terminal = true;
             return;
         };
         let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME"));
-        let password = app.state::<Engine>().password.clone();
-        let mut command = Command::new(binary);
-        command
-            .args(["serve", "--hostname", "127.0.0.1", "--port", "0"])
-            .env("OPENCODE_SERVER_PASSWORD", password)
-            .env("OPENCODE_SERVER_USERNAME", "opencode")
-            .env_remove("OPENCODE_CONFIG")
-            .env_remove("OPENCODE_CONFIG_CONTENT")
-            .env("OPENCODE_CONFIG_DIR", config_dir)
-            .env("DRIFT_MCP_APPROVAL_REQUIRED", "1")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        if shared_database {
-            engine_db::configure_shared(&mut command);
-        }
-        if let Ok(home) = home {
-            command.current_dir(home);
-        }
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            command.creation_flags(0x0800_0000);
-        }
-        let mut child = match command.spawn() {
-            Ok(child) => child,
-            Err(error) => {
-                *app.state::<Engine>().diagnostic.lock().unwrap() =
-                    format!("failed to start embedded engine: {error}");
+        let mut crashes = 0;
+        loop {
+            let engine = app.state::<Engine>();
+            if engine.shutting_down.load(Ordering::SeqCst) {
                 return;
             }
-        };
-        let stdout = child.stdout.take();
-        let stderr = child.stderr.take();
-        let engine = app.state::<Engine>();
-        *engine.child.lock().unwrap() = Some(child);
-        if let Some(stderr) = stderr {
-            let diagnostics_app = app.clone();
-            std::thread::spawn(move || {
-                for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                    if !line.trim().is_empty() {
-                        *diagnostics_app.state::<Engine>().diagnostic.lock().unwrap() = line;
+
+            let password = engine_password();
+            let generation = {
+                let mut process = engine.process.lock().unwrap();
+                process.generation += 1;
+                process.url = None;
+                process.child = None;
+                process.diagnostic.clear();
+                process.password = Some(password.clone());
+                process.terminal = false;
+                process.generation
+            };
+            let started = Instant::now();
+            let mut command = Command::new(&binary);
+            command
+                .args(["serve", "--hostname", "127.0.0.1", "--port", "0"])
+                .env("OPENCODE_SERVER_PASSWORD", &password)
+                .env("OPENCODE_SERVER_USERNAME", "opencode")
+                .env_remove("OPENCODE_CONFIG")
+                .env_remove("OPENCODE_CONFIG_CONTENT")
+                .env("OPENCODE_CONFIG_DIR", &config_dir)
+                .env("DRIFT_MCP_APPROVAL_REQUIRED", "1")
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            if shared_database {
+                engine_db::configure_shared(&mut command);
+            }
+            if let Ok(home) = &home {
+                command.current_dir(home);
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                command.creation_flags(0x0800_0000);
+            }
+
+            let mut exit = None;
+            match command.spawn() {
+                Ok(mut child) => {
+                    let stdout = child.stdout.take();
+                    let stderr = child.stderr.take();
+                    engine.process.lock().unwrap().child = Some(child);
+                    if let Some(stderr) = stderr {
+                        let diagnostics_app = app.clone();
+                        std::thread::spawn(move || {
+                            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                                if line.trim().is_empty() {
+                                    continue;
+                                }
+                                let engine = diagnostics_app.state::<Engine>();
+                                let mut process = engine.process.lock().unwrap();
+                                if process.generation == generation {
+                                    process.diagnostic = line;
+                                }
+                            }
+                        });
+                    }
+                    if let Some(stdout) = stdout {
+                        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                            if let Some(index) = line.find("http://") {
+                                let mut process = engine.process.lock().unwrap();
+                                if process.generation == generation {
+                                    process.url = Some(line[index..].trim().to_string());
+                                }
+                            }
+                        }
+                    }
+                    let mut process = engine.process.lock().unwrap();
+                    if process.generation == generation {
+                        exit = process.child.take().and_then(|mut child| child.wait().ok());
                     }
                 }
-            });
-        }
-        let Some(stdout) = stdout else { return };
-        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-            if let Some(index) = line.find("http://") {
-                let engine = app.state::<Engine>();
-                *engine.url.lock().unwrap() = Some(line[index..].trim().to_string());
+                Err(error) => {
+                    engine.process.lock().unwrap().diagnostic =
+                        format!("failed to start embedded engine: {error}");
+                }
+            }
+            let requested = engine.restart_requested.swap(false, Ordering::SeqCst);
+            let shutting_down = engine.shutting_down.load(Ordering::SeqCst);
+            {
+                let mut process = engine.process.lock().unwrap();
+                if process.generation == generation {
+                    process.url = None;
+                    if !shutting_down && !requested {
+                        let summary = exit
+                            .map(|status| format!("embedded engine exited with {status}"))
+                            .unwrap_or_else(|| "embedded engine stopped unexpectedly".into());
+                        process.diagnostic = if process.diagnostic.is_empty() {
+                            summary
+                        } else {
+                            format!("{summary}: {}", process.diagnostic)
+                        };
+                    }
+                }
+            }
+            if shutting_down {
+                return;
+            }
+            if requested || started.elapsed() >= ENGINE_STABLE_AFTER {
+                crashes = 0;
+            } else {
+                crashes += 1;
+            }
+            let Some(delay) = restart_delay(crashes) else {
+                engine.process.lock().unwrap().terminal = true;
+                return;
+            };
+            if !wait_for_restart(&engine, delay) {
+                return;
             }
         }
-        *app.state::<Engine>().url.lock().unwrap() = None;
     });
 }
 
 fn stop_engine_instances(app: &tauri::AppHandle) -> Result<(), String> {
     let engine = app.state::<Engine>();
-    let Some(url) = engine.url.lock().unwrap().clone() else {
-        return Ok(());
+    let (url, password) = {
+        let process = engine.process.lock().unwrap();
+        let Some(url) = process.url.clone() else {
+            return Ok(());
+        };
+        let Some(password) = process.password.clone() else {
+            return Ok(());
+        };
+        (url, password)
     };
-    let parsed = url::Url::parse(&url).map_err(|error| error.to_string())?;
-    let host = parsed.host_str().ok_or("embedded engine URL has no host")?;
-    let port = parsed
-        .port_or_known_default()
-        .ok_or("embedded engine URL has no port")?;
-    let mut stream = TcpStream::connect((host, port)).map_err(|error| error.to_string())?;
-    stream
-        .set_read_timeout(Some(std::time::Duration::from_secs(3)))
-        .map_err(|error| error.to_string())?;
-    let authorization = basic_authorization("opencode", &engine.password);
-    let request = format!(
-        "POST /global/dispose HTTP/1.1\r\nHost: {host}:{port}\r\nAuthorization: Basic {authorization}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
-    );
-    stream
-        .write_all(request.as_bytes())
-        .map_err(|error| error.to_string())?;
-    let mut response = String::new();
-    BufReader::new(stream)
-        .read_line(&mut response)
-        .map_err(|error| error.to_string())?;
-    if !response.starts_with("HTTP/1.1 200") {
-        return Err("embedded engine refused global disposal".into());
+    engine.restart_requested.store(true, Ordering::SeqCst);
+    let result = (|| {
+        let parsed = url::Url::parse(&url).map_err(|error| error.to_string())?;
+        let host = parsed.host_str().ok_or("embedded engine URL has no host")?;
+        let port = parsed
+            .port_or_known_default()
+            .ok_or("embedded engine URL has no port")?;
+        let mut stream = TcpStream::connect((host, port)).map_err(|error| error.to_string())?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(3)))
+            .map_err(|error| error.to_string())?;
+        let authorization = basic_authorization("opencode", &password);
+        let request = format!(
+            "POST /global/dispose HTTP/1.1\r\nHost: {host}:{port}\r\nAuthorization: Basic {authorization}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        stream
+            .write_all(request.as_bytes())
+            .map_err(|error| error.to_string())?;
+        let mut response = String::new();
+        BufReader::new(stream)
+            .read_line(&mut response)
+            .map_err(|error| error.to_string())?;
+        if !response.starts_with("HTTP/1.1 200") {
+            return Err("embedded engine refused global disposal".into());
+        }
+        Ok(())
+    })();
+    if result.is_err() {
+        engine.restart_requested.store(false, Ordering::SeqCst);
     }
-    Ok(())
+    result
 }
 
 fn basic_authorization(username: &str, password: &str) -> String {
@@ -989,11 +1096,12 @@ fn main() {
             store_save_workspace,
             store_touch_workspace,
             store_remove_workspace,
-            store_purge_removed_workspaces,
+            store_prepare_deletions,
+            store_stage_workspace_deletion,
+            store_confirm_deletions,
             store_archived,
             store_archive_session,
             store_unarchive_session,
-            store_purge_archived,
             mcp_snapshot,
             prompt_snapshot,
             prompt_save,
@@ -1050,7 +1158,8 @@ fn main() {
         .run(|app, event| {
             if let RunEvent::Exit = event {
                 let engine = app.state::<Engine>();
-                let child = engine.child.lock().unwrap().take();
+                engine.shutting_down.store(true, Ordering::SeqCst);
+                let child = engine.process.lock().unwrap().child.take();
                 if let Some(mut child) = child {
                     let _ = child.kill();
                 }
@@ -1062,7 +1171,8 @@ fn main() {
 mod tests {
     use super::{
         basic_authorization, clipboard_utf16, config_path, editor_arguments, editor_kind,
-        file_signatures, watched_mcp_paths, EditorKind, Engine,
+        engine_password, file_signatures, restart_delay, watched_mcp_paths, EditorKind,
+        MAX_ENGINE_RESTARTS,
     };
     use std::path::Path;
 
@@ -1100,11 +1210,19 @@ mod tests {
 
     #[test]
     fn engine_credentials_are_random_and_basic_auth_encoded() {
-        let first = Engine::default().password;
-        let second = Engine::default().password;
+        let first = engine_password();
+        let second = engine_password();
         assert_eq!(first.len(), 64);
         assert_ne!(first, second);
         assert_eq!(basic_authorization("user", "pass"), "dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn engine_crash_restarts_are_bounded() {
+        for crash in 1..=MAX_ENGINE_RESTARTS {
+            assert!(restart_delay(crash).is_some());
+        }
+        assert!(restart_delay(MAX_ENGINE_RESTARTS + 1).is_none());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -403,7 +403,7 @@ fn store_add_workspace(
 ) -> Result<Workspace, String> {
     store
         .add_workspace(&id, &path, &name, &icon)
-        .map_err(|e| e.to_string())
+        .map_err(restore_store_error)
 }
 
 #[tauri::command]
@@ -470,6 +470,17 @@ fn store_confirm_deletions(
 }
 
 #[tauri::command]
+fn store_finalize_deletions(
+    store: State<Store>,
+    confirmed: Vec<PendingSessionDeletion>,
+    retry: Vec<PendingSessionDeletion>,
+) -> Result<(), String> {
+    store
+        .finalize_deletions(&confirmed, &retry)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn store_archived(store: State<Store>) -> Result<Vec<ArchivedSession>, String> {
     store.archived().map_err(|e| e.to_string())
 }
@@ -489,7 +500,14 @@ fn store_archive_session(
 fn store_unarchive_session(store: State<Store>, session_id: String) -> Result<(), String> {
     store
         .unarchive_session(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(restore_store_error)
+}
+
+fn restore_store_error(error: rusqlite::Error) -> String {
+    if matches!(error, rusqlite::Error::InvalidQuery) {
+        return "Deletion is in progress. Wait for it to finish, then try restoring again.".into();
+    }
+    error.to_string()
 }
 
 #[tauri::command]
@@ -1134,6 +1152,7 @@ fn main() {
             store_claim_deletions,
             store_release_deletions,
             store_confirm_deletions,
+            store_finalize_deletions,
             store_archived,
             store_archive_session,
             store_unarchive_session,
@@ -1206,8 +1225,8 @@ fn main() {
 mod tests {
     use super::{
         basic_authorization, clipboard_utf16, config_path, editor_arguments, editor_kind,
-        engine_password, file_signatures, publish_engine_child, restart_delay, watched_mcp_paths,
-        EditorKind, Engine, MAX_ENGINE_RESTARTS,
+        engine_password, file_signatures, publish_engine_child, restart_delay, restore_store_error,
+        watched_mcp_paths, EditorKind, Engine, MAX_ENGINE_RESTARTS,
     };
     use std::path::Path;
     use std::process::{Command, Stdio};
@@ -1252,6 +1271,14 @@ mod tests {
         assert_eq!(first.len(), 64);
         assert_ne!(first, second);
         assert_eq!(basic_authorization("user", "pass"), "dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn restore_claim_conflicts_have_actionable_errors() {
+        assert_eq!(
+            restore_store_error(rusqlite::Error::InvalidQuery),
+            "Deletion is in progress. Wait for it to finish, then try restoring again."
+        );
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -446,10 +446,19 @@ fn store_stage_workspace_deletion(
 }
 
 #[tauri::command]
-fn store_confirm_deletions(store: State<Store>, session_ids: Vec<String>) -> Result<(), String> {
-    store
-        .confirm_deletions(&session_ids)
-        .map_err(|e| e.to_string())
+fn store_claim_deletions(
+    store: State<Store>,
+    entries: Vec<PendingSessionDeletion>,
+) -> Result<Vec<PendingSessionDeletion>, String> {
+    store.claim_deletions(&entries).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn store_confirm_deletions(
+    store: State<Store>,
+    entries: Vec<PendingSessionDeletion>,
+) -> Result<(), String> {
+    store.confirm_deletions(&entries).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -654,6 +663,15 @@ fn wait_for_restart(engine: &Engine, delay: Duration) -> bool {
     true
 }
 
+fn publish_engine_child(engine: &Engine, generation: u64, child: Child) -> Option<Child> {
+    let mut process = engine.process.lock().unwrap();
+    if engine.shutting_down.load(Ordering::SeqCst) || process.generation != generation {
+        return Some(child);
+    }
+    process.child = Some(child);
+    None
+}
+
 fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBuf) {
     std::thread::spawn(move || {
         let Some(binary) = engine_binary() else {
@@ -711,7 +729,11 @@ fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBu
                 Ok(mut child) => {
                     let stdout = child.stdout.take();
                     let stderr = child.stderr.take();
-                    engine.process.lock().unwrap().child = Some(child);
+                    if let Some(mut late) = publish_engine_child(&engine, generation, child) {
+                        let _ = late.kill();
+                        let _ = late.wait();
+                        return;
+                    }
                     if let Some(stderr) = stderr {
                         let diagnostics_app = app.clone();
                         std::thread::spawn(move || {
@@ -737,10 +759,13 @@ fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBu
                             }
                         }
                     }
-                    let mut process = engine.process.lock().unwrap();
-                    if process.generation == generation {
-                        exit = process.child.take().and_then(|mut child| child.wait().ok());
-                    }
+                    let child = {
+                        let mut process = engine.process.lock().unwrap();
+                        (process.generation == generation)
+                            .then(|| process.child.take())
+                            .flatten()
+                    };
+                    exit = child.and_then(|mut child| child.wait().ok());
                 }
                 Err(error) => {
                     engine.process.lock().unwrap().diagnostic =
@@ -1098,6 +1123,7 @@ fn main() {
             store_remove_workspace,
             store_prepare_deletions,
             store_stage_workspace_deletion,
+            store_claim_deletions,
             store_confirm_deletions,
             store_archived,
             store_archive_session,
@@ -1171,10 +1197,12 @@ fn main() {
 mod tests {
     use super::{
         basic_authorization, clipboard_utf16, config_path, editor_arguments, editor_kind,
-        engine_password, file_signatures, restart_delay, watched_mcp_paths, EditorKind,
-        MAX_ENGINE_RESTARTS,
+        engine_password, file_signatures, publish_engine_child, restart_delay, watched_mcp_paths,
+        EditorKind, Engine, MAX_ENGINE_RESTARTS,
     };
     use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::sync::atomic::Ordering;
 
     #[test]
     fn config_paths_stay_under_the_config_directory() {
@@ -1223,6 +1251,31 @@ mod tests {
             assert!(restart_delay(crash).is_some());
         }
         assert!(restart_delay(MAX_ENGINE_RESTARTS + 1).is_none());
+    }
+
+    #[test]
+    fn engine_child_is_not_published_after_shutdown_starts() {
+        let engine = Engine::default();
+        engine.process.lock().unwrap().generation = 1;
+        engine.shutting_down.store(true, Ordering::SeqCst);
+        #[cfg(windows)]
+        let child = Command::new("cmd")
+            .args(["/C", "ping", "127.0.0.1", "-n", "30"])
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+        #[cfg(not(windows))]
+        let child = Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+
+        let mut rejected =
+            publish_engine_child(&engine, 1, child).expect("late child was published");
+        assert!(engine.process.lock().unwrap().child.is_none());
+        rejected.kill().unwrap();
+        rejected.wait().unwrap();
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -454,6 +454,14 @@ fn store_claim_deletions(
 }
 
 #[tauri::command]
+fn store_release_deletions(
+    store: State<Store>,
+    entries: Vec<PendingSessionDeletion>,
+) -> Result<(), String> {
+    store.release_deletions(&entries).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn store_confirm_deletions(
     store: State<Store>,
     entries: Vec<PendingSessionDeletion>,
@@ -1124,6 +1132,7 @@ fn main() {
             store_prepare_deletions,
             store_stage_workspace_deletion,
             store_claim_deletions,
+            store_release_deletions,
             store_confirm_deletions,
             store_archived,
             store_archive_session,

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -28,6 +28,20 @@ pub struct ArchivedSession {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct PendingSessionDeletion {
+    pub session_id: String,
+    pub directory: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletionSweep {
+    pub pending: Vec<PendingSessionDeletion>,
+    pub workspaces: Vec<Workspace>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct McpServer {
     pub name: String,
     pub config: Value,
@@ -77,7 +91,8 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
             name TEXT NOT NULL,
             icon TEXT NOT NULL DEFAULT '',
             last_used INTEGER NOT NULL DEFAULT 0,
-            removed_at INTEGER
+            removed_at INTEGER,
+            purge_staged_at INTEGER
         ) STRICT;
         CREATE TABLE IF NOT EXISTS session_meta(
             session_id TEXT PRIMARY KEY,
@@ -85,6 +100,14 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
             archived_at INTEGER
         ) STRICT;
         CREATE INDEX IF NOT EXISTS idx_session_meta_workspace ON session_meta(workspace_id);
+        CREATE TABLE IF NOT EXISTS pending_session_delete(
+            session_id TEXT PRIMARY KEY,
+            directory TEXT NOT NULL,
+            workspace_id TEXT,
+            queued_at INTEGER NOT NULL
+        ) STRICT;
+        CREATE INDEX IF NOT EXISTS idx_pending_session_delete_workspace
+            ON pending_session_delete(workspace_id);
         CREATE TABLE IF NOT EXISTS mcp_server(
             name TEXT PRIMARY KEY,
             config_json TEXT NOT NULL,
@@ -110,6 +133,10 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
         ) STRICT;",
     )?;
     let _ = conn.execute("ALTER TABLE workspace ADD COLUMN removed_at INTEGER", []);
+    let _ = conn.execute(
+        "ALTER TABLE workspace ADD COLUMN purge_staged_at INTEGER",
+        [],
+    );
     Ok(Store(Mutex::new(conn)))
 }
 
@@ -118,6 +145,30 @@ fn now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+fn workspace_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Workspace> {
+    Ok(Workspace {
+        id: row.get(0)?,
+        path: row.get(1)?,
+        name: row.get(2)?,
+        icon: row.get(3)?,
+        last_used: row.get(4)?,
+        removed_at: row.get(5)?,
+    })
+}
+
+fn pending_deletions(conn: &Connection) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
+    conn.prepare_cached(
+        "SELECT session_id, directory FROM pending_session_delete ORDER BY queued_at, session_id",
+    )?
+    .query_map([], |row| {
+        Ok(PendingSessionDeletion {
+            session_id: row.get(0)?,
+            directory: row.get(1)?,
+        })
+    })?
+    .collect()
 }
 
 impl Store {
@@ -277,9 +328,11 @@ impl Store {
         let target = match existing {
             Some(found) => {
                 conn.prepare_cached(
-                    "UPDATE workspace SET removed_at = NULL, last_used = ?2 WHERE id = ?1",
+                    "UPDATE workspace SET removed_at = NULL, purge_staged_at = NULL, last_used = ?2 WHERE id = ?1",
                 )?
                 .execute((&found, now()))?;
+                conn.prepare_cached("DELETE FROM pending_session_delete WHERE workspace_id = ?1")?
+                    .execute([&found])?;
                 found
             }
             None => {
@@ -335,23 +388,6 @@ impl Store {
         Ok(())
     }
 
-    pub fn purge_removed_workspaces(&self, before: i64) -> rusqlite::Result<Vec<String>> {
-        let conn = self.0.lock().unwrap();
-        let rows: Vec<(String, String)> = conn
-            .prepare_cached(
-                "SELECT id, path FROM workspace WHERE removed_at IS NOT NULL AND removed_at < ?1",
-            )?
-            .query_map([before], |row| Ok((row.get(0)?, row.get(1)?)))?
-            .collect::<Result<_, _>>()?;
-        for (id, _) in &rows {
-            conn.prepare_cached("DELETE FROM session_meta WHERE workspace_id = ?1")?
-                .execute([id])?;
-            conn.prepare_cached("DELETE FROM workspace WHERE id = ?1")?
-                .execute([id])?;
-        }
-        Ok(rows.into_iter().map(|(_, path)| path).collect())
-    }
-
     pub fn archived(&self) -> rusqlite::Result<Vec<ArchivedSession>> {
         let conn = self.0.lock().unwrap();
         let mut stmt = conn.prepare_cached(
@@ -371,6 +407,8 @@ impl Store {
         let conn = self.0.lock().unwrap();
         conn.prepare_cached("DELETE FROM session_meta WHERE session_id = ?1")?
             .execute([session_id])?;
+        conn.prepare_cached("DELETE FROM pending_session_delete WHERE session_id = ?1")?
+            .execute([session_id])?;
         Ok(())
     }
 
@@ -384,17 +422,100 @@ impl Store {
         Ok(())
     }
 
-    pub fn purge_archived(&self, before: i64) -> rusqlite::Result<Vec<String>> {
-        let conn = self.0.lock().unwrap();
-        let ids: Vec<String> = conn
-            .prepare_cached("SELECT session_id FROM session_meta WHERE archived_at IS NOT NULL AND archived_at < ?1")?
-            .query_map([before], |row| row.get(0))?
+    pub fn prepare_deletions(&self, before: i64) -> rusqlite::Result<DeletionSweep> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.execute(
+            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
+             SELECT meta.session_id, workspace.path, meta.workspace_id, ?2
+             FROM session_meta meta JOIN workspace ON workspace.id = meta.workspace_id
+             WHERE meta.archived_at IS NOT NULL AND meta.archived_at < ?1",
+            params![before, now()],
+        )?;
+        let pending = pending_deletions(&tx)?;
+        let workspaces = tx
+            .prepare_cached(
+                "SELECT id, path, name, icon, last_used, removed_at FROM workspace
+                 WHERE removed_at IS NOT NULL AND removed_at < ?1 AND purge_staged_at IS NULL
+                 ORDER BY removed_at",
+            )?
+            .query_map([before], workspace_row)?
             .collect::<Result<_, _>>()?;
-        conn.prepare_cached(
-            "DELETE FROM session_meta WHERE archived_at IS NOT NULL AND archived_at < ?1",
-        )?
-        .execute([before])?;
-        Ok(ids)
+        tx.commit()?;
+        Ok(DeletionSweep {
+            pending,
+            workspaces,
+        })
+    }
+
+    pub fn stage_workspace_deletion(
+        &self,
+        workspace_id: &str,
+        session_ids: &[String],
+    ) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let directory: Option<String> = tx
+            .prepare_cached("SELECT path FROM workspace WHERE id = ?1 AND removed_at IS NOT NULL")?
+            .query_row([workspace_id], |row| row.get(0))
+            .optional()?;
+        let Some(directory) = directory else {
+            tx.commit()?;
+            return pending_deletions(&conn);
+        };
+        let queued_at = now();
+        for session_id in session_ids {
+            tx.execute(
+                "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
+                 VALUES(?1, ?2, ?3, ?4)",
+                params![session_id, directory, workspace_id, queued_at],
+            )?;
+            tx.execute(
+                "UPDATE pending_session_delete SET directory = ?2, workspace_id = ?3 WHERE session_id = ?1",
+                params![session_id, directory, workspace_id],
+            )?;
+        }
+        tx.execute(
+            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
+             SELECT session_id, ?2, ?1, ?3 FROM session_meta WHERE workspace_id = ?1",
+            params![workspace_id, directory, queued_at],
+        )?;
+        tx.execute(
+            "UPDATE pending_session_delete SET directory = ?2, workspace_id = ?1
+             WHERE session_id IN (SELECT session_id FROM session_meta WHERE workspace_id = ?1)",
+            params![workspace_id, directory],
+        )?;
+        tx.execute(
+            "UPDATE workspace SET purge_staged_at = ?2 WHERE id = ?1 AND removed_at IS NOT NULL",
+            params![workspace_id, queued_at],
+        )?;
+        let pending = pending_deletions(&tx)?;
+        tx.commit()?;
+        Ok(pending)
+    }
+
+    pub fn confirm_deletions(&self, session_ids: &[String]) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        for session_id in session_ids {
+            tx.execute(
+                "DELETE FROM pending_session_delete WHERE session_id = ?1",
+                [session_id],
+            )?;
+            tx.execute(
+                "DELETE FROM session_meta WHERE session_id = ?1",
+                [session_id],
+            )?;
+        }
+        tx.execute(
+            "DELETE FROM workspace
+             WHERE removed_at IS NOT NULL AND purge_staged_at IS NOT NULL
+               AND NOT EXISTS (
+                   SELECT 1 FROM pending_session_delete pending WHERE pending.workspace_id = workspace.id
+               )",
+            [],
+        )?;
+        tx.commit()
     }
 
     pub fn mcp_state(&self) -> rusqlite::Result<McpState> {
@@ -609,8 +730,13 @@ mod tests {
         assert_eq!(store.archived().unwrap().len(), 2);
         store.unarchive_session("s1").unwrap();
         assert_eq!(store.archived().unwrap().len(), 1);
-        let purged = store.purge_archived(now() + 1000).unwrap();
-        assert_eq!(purged.len(), 1);
+        let sweep = store.prepare_deletions(now() + 1000).unwrap();
+        assert_eq!(sweep.pending.len(), 1);
+        assert_eq!(sweep.pending[0].session_id, "s2");
+        assert_eq!(store.archived().unwrap().len(), 1);
+        store
+            .confirm_deletions(&[sweep.pending[0].session_id.clone()])
+            .unwrap();
         assert!(store.archived().unwrap().is_empty());
 
         store.remove_workspace("w1").unwrap();
@@ -625,8 +751,13 @@ mod tests {
         assert_eq!(store.workspaces().unwrap().len(), 1);
 
         store.remove_workspace("w1").unwrap();
-        let paths = store.purge_removed_workspaces(now() + 1000).unwrap();
-        assert_eq!(paths, vec!["S:/moved".to_string()]);
+        let sweep = store.prepare_deletions(now() + 1000).unwrap();
+        assert_eq!(sweep.workspaces.len(), 1);
+        let pending = store
+            .stage_workspace_deletion("w1", &["old-session".into()])
+            .unwrap();
+        assert_eq!(pending[0].session_id, "old-session");
+        store.confirm_deletions(&["old-session".into()]).unwrap();
         assert!(store.workspaces().unwrap().is_empty());
         assert!(
             store
@@ -700,6 +831,46 @@ mod tests {
             "Custom"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn deletion_tombstones_survive_partial_confirmation_and_cancel_on_restore() {
+        let dir = std::env::temp_dir().join(format!("drift-delete-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let database = dir.join("drift.db");
+        {
+            let store = open_at(&database).unwrap();
+            store
+                .add_workspace("w1", "S:/reused", "Reused", "")
+                .unwrap();
+            store.archive_session("archived", "w1").unwrap();
+            store.remove_workspace("w1").unwrap();
+            let sweep = store.prepare_deletions(now() + 1000).unwrap();
+            assert_eq!(sweep.pending[0].session_id, "archived");
+            let pending = store
+                .stage_workspace_deletion("w1", &["live".into()])
+                .unwrap();
+            assert_eq!(pending.len(), 2);
+            store.confirm_deletions(&["archived".into()]).unwrap();
+            assert_eq!(store.removed_workspaces().unwrap().len(), 1);
+        }
+        {
+            let store = open_at(&database).unwrap();
+            let sweep = store.prepare_deletions(now() + 1000).unwrap();
+            assert_eq!(sweep.pending.len(), 1);
+            assert_eq!(sweep.pending[0].session_id, "live");
+            let restored = store
+                .add_workspace("new-id", "S:/reused", "New", "")
+                .unwrap();
+            assert_eq!(restored.id, "w1");
+            assert!(store
+                .prepare_deletions(now() + 1000)
+                .unwrap()
+                .pending
+                .is_empty());
+        }
+        std::fs::remove_dir_all(dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -26,11 +26,12 @@ pub struct ArchivedSession {
     pub archived_at: i64,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PendingSessionDeletion {
     pub session_id: String,
     pub directory: String,
+    pub claim: String,
 }
 
 #[derive(Serialize)]
@@ -104,7 +105,8 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
             session_id TEXT PRIMARY KEY,
             directory TEXT NOT NULL,
             workspace_id TEXT,
-            queued_at INTEGER NOT NULL
+            queued_at INTEGER NOT NULL,
+            claim TEXT NOT NULL
         ) STRICT;
         CREATE INDEX IF NOT EXISTS idx_pending_session_delete_workspace
             ON pending_session_delete(workspace_id);
@@ -137,6 +139,10 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
         "ALTER TABLE workspace ADD COLUMN purge_staged_at INTEGER",
         [],
     );
+    let _ = conn.execute(
+        "ALTER TABLE pending_session_delete ADD COLUMN claim TEXT NOT NULL DEFAULT ''",
+        [],
+    );
     Ok(Store(Mutex::new(conn)))
 }
 
@@ -145,6 +151,12 @@ fn now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
+}
+
+fn deletion_claim() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).expect("failed to generate deletion claim");
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 fn workspace_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Workspace> {
@@ -160,12 +172,13 @@ fn workspace_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Workspace> {
 
 fn pending_deletions(conn: &Connection) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
     conn.prepare_cached(
-        "SELECT session_id, directory FROM pending_session_delete ORDER BY queued_at, session_id",
+        "SELECT session_id, directory, claim FROM pending_session_delete ORDER BY queued_at, session_id",
     )?
     .query_map([], |row| {
         Ok(PendingSessionDeletion {
             session_id: row.get(0)?,
             directory: row.get(1)?,
+            claim: row.get(2)?,
         })
     })?
     .collect()
@@ -320,28 +333,29 @@ impl Store {
         name: &str,
         icon: &str,
     ) -> rusqlite::Result<Workspace> {
-        let conn = self.0.lock().unwrap();
-        let existing: Option<String> = conn
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let existing: Option<String> = tx
             .prepare_cached("SELECT id FROM workspace WHERE path = ?1")?
             .query_row([path], |row| row.get(0))
             .optional()?;
         let target = match existing {
             Some(found) => {
-                conn.prepare_cached(
+                tx.prepare_cached(
                     "UPDATE workspace SET removed_at = NULL, purge_staged_at = NULL, last_used = ?2 WHERE id = ?1",
                 )?
                 .execute((&found, now()))?;
-                conn.prepare_cached("DELETE FROM pending_session_delete WHERE workspace_id = ?1")?
+                tx.prepare_cached("DELETE FROM pending_session_delete WHERE workspace_id = ?1")?
                     .execute([&found])?;
                 found
             }
             None => {
-                conn.prepare_cached("INSERT INTO workspace(id, path, name, icon, last_used) VALUES(?1, ?2, ?3, ?4, ?5)")?
+                tx.prepare_cached("INSERT INTO workspace(id, path, name, icon, last_used) VALUES(?1, ?2, ?3, ?4, ?5)")?
                     .execute((id, path, name, icon, now()))?;
                 id.to_string()
             }
         };
-        let workspace = conn
+        let workspace = tx
             .prepare_cached(
                 "SELECT id, path, name, icon, last_used, removed_at FROM workspace WHERE id = ?1",
             )?
@@ -355,6 +369,7 @@ impl Store {
                     removed_at: row.get(5)?,
                 })
             })?;
+        tx.commit()?;
         Ok(workspace)
     }
 
@@ -404,12 +419,13 @@ impl Store {
     }
 
     pub fn unarchive_session(&self, session_id: &str) -> rusqlite::Result<()> {
-        let conn = self.0.lock().unwrap();
-        conn.prepare_cached("DELETE FROM session_meta WHERE session_id = ?1")?
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        tx.prepare_cached("DELETE FROM session_meta WHERE session_id = ?1")?
             .execute([session_id])?;
-        conn.prepare_cached("DELETE FROM pending_session_delete WHERE session_id = ?1")?
+        tx.prepare_cached("DELETE FROM pending_session_delete WHERE session_id = ?1")?
             .execute([session_id])?;
-        Ok(())
+        tx.commit()
     }
 
     pub fn archive_session(&self, session_id: &str, workspace_id: &str) -> rusqlite::Result<()> {
@@ -426,11 +442,15 @@ impl Store {
         let mut conn = self.0.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
         tx.execute(
-            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
-             SELECT meta.session_id, workspace.path, meta.workspace_id, ?2
+            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at, claim)
+             SELECT meta.session_id, workspace.path, meta.workspace_id, ?2, ?3
              FROM session_meta meta JOIN workspace ON workspace.id = meta.workspace_id
              WHERE meta.archived_at IS NOT NULL AND meta.archived_at < ?1",
-            params![before, now()],
+            params![before, now(), deletion_claim()],
+        )?;
+        tx.execute(
+            "UPDATE pending_session_delete SET claim = ?1 WHERE claim = ''",
+            [deletion_claim()],
         )?;
         let pending = pending_deletions(&tx)?;
         let workspaces = tx
@@ -464,11 +484,12 @@ impl Store {
             return pending_deletions(&conn);
         };
         let queued_at = now();
+        let claim = deletion_claim();
         for session_id in session_ids {
             tx.execute(
-                "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
-                 VALUES(?1, ?2, ?3, ?4)",
-                params![session_id, directory, workspace_id, queued_at],
+                "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at, claim)
+                 VALUES(?1, ?2, ?3, ?4, ?5)",
+                params![session_id, directory, workspace_id, queued_at, claim],
             )?;
             tx.execute(
                 "UPDATE pending_session_delete SET directory = ?2, workspace_id = ?3 WHERE session_id = ?1",
@@ -476,9 +497,9 @@ impl Store {
             )?;
         }
         tx.execute(
-            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at)
-             SELECT session_id, ?2, ?1, ?3 FROM session_meta WHERE workspace_id = ?1",
-            params![workspace_id, directory, queued_at],
+            "INSERT OR IGNORE INTO pending_session_delete(session_id, directory, workspace_id, queued_at, claim)
+             SELECT session_id, ?2, ?1, ?3, ?4 FROM session_meta WHERE workspace_id = ?1",
+            params![workspace_id, directory, queued_at, claim],
         )?;
         tx.execute(
             "UPDATE pending_session_delete SET directory = ?2, workspace_id = ?1
@@ -494,18 +515,47 @@ impl Store {
         Ok(pending)
     }
 
-    pub fn confirm_deletions(&self, session_ids: &[String]) -> rusqlite::Result<()> {
+    pub fn claim_deletions(
+        &self,
+        entries: &[PendingSessionDeletion],
+    ) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
+        let conn = self.0.lock().unwrap();
+        let mut claimed = Vec::new();
+        for entry in entries {
+            let current = conn
+                .prepare_cached(
+                    "SELECT session_id, directory, claim FROM pending_session_delete
+                     WHERE session_id = ?1 AND claim = ?2",
+                )?
+                .query_row(params![entry.session_id, entry.claim], |row| {
+                    Ok(PendingSessionDeletion {
+                        session_id: row.get(0)?,
+                        directory: row.get(1)?,
+                        claim: row.get(2)?,
+                    })
+                })
+                .optional()?;
+            if let Some(current) = current {
+                claimed.push(current);
+            }
+        }
+        Ok(claimed)
+    }
+
+    pub fn confirm_deletions(&self, entries: &[PendingSessionDeletion]) -> rusqlite::Result<()> {
         let mut conn = self.0.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        for session_id in session_ids {
-            tx.execute(
-                "DELETE FROM pending_session_delete WHERE session_id = ?1",
-                [session_id],
+        for entry in entries {
+            let removed = tx.execute(
+                "DELETE FROM pending_session_delete WHERE session_id = ?1 AND claim = ?2",
+                params![entry.session_id, entry.claim],
             )?;
-            tx.execute(
-                "DELETE FROM session_meta WHERE session_id = ?1",
-                [session_id],
-            )?;
+            if removed == 1 {
+                tx.execute(
+                    "DELETE FROM session_meta WHERE session_id = ?1",
+                    [&entry.session_id],
+                )?;
+            }
         }
         tx.execute(
             "DELETE FROM workspace
@@ -735,7 +785,7 @@ mod tests {
         assert_eq!(sweep.pending[0].session_id, "s2");
         assert_eq!(store.archived().unwrap().len(), 1);
         store
-            .confirm_deletions(&[sweep.pending[0].session_id.clone()])
+            .confirm_deletions(&[sweep.pending[0].clone()])
             .unwrap();
         assert!(store.archived().unwrap().is_empty());
 
@@ -757,7 +807,11 @@ mod tests {
             .stage_workspace_deletion("w1", &["old-session".into()])
             .unwrap();
         assert_eq!(pending[0].session_id, "old-session");
-        store.confirm_deletions(&["old-session".into()]).unwrap();
+        let old_session = pending
+            .into_iter()
+            .find(|entry| entry.session_id == "old-session")
+            .unwrap();
+        store.confirm_deletions(&[old_session]).unwrap();
         assert!(store.workspaces().unwrap().is_empty());
         assert!(
             store
@@ -852,7 +906,11 @@ mod tests {
                 .stage_workspace_deletion("w1", &["live".into()])
                 .unwrap();
             assert_eq!(pending.len(), 2);
-            store.confirm_deletions(&["archived".into()]).unwrap();
+            let archived = pending
+                .into_iter()
+                .find(|entry| entry.session_id == "archived")
+                .unwrap();
+            store.confirm_deletions(&[archived]).unwrap();
             assert_eq!(store.removed_workspaces().unwrap().len(), 1);
         }
         {
@@ -870,6 +928,48 @@ mod tests {
                 .pending
                 .is_empty());
         }
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn stale_deletion_claims_cannot_delete_restored_or_replaced_metadata() {
+        let dir = std::env::temp_dir().join(format!("drift-claim-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = open_at(&dir.join("drift.db")).unwrap();
+        store.add_workspace("w1", "S:/claim", "Claim", "").unwrap();
+        store.archive_session("session", "w1").unwrap();
+
+        let stale = store.prepare_deletions(now() + 1000).unwrap().pending[0].clone();
+        store.unarchive_session("session").unwrap();
+        assert!(store.claim_deletions(&[stale.clone()]).unwrap().is_empty());
+
+        store.archive_session("session", "w1").unwrap();
+        let replacement = store.prepare_deletions(now() + 1000).unwrap().pending[0].clone();
+        assert_ne!(stale.claim, replacement.claim);
+        store.confirm_deletions(&[stale]).unwrap();
+        assert_eq!(store.archived().unwrap().len(), 1);
+        assert_eq!(
+            store.claim_deletions(&[replacement.clone()]).unwrap()[0].claim,
+            replacement.claim
+        );
+
+        store.remove_workspace("w1").unwrap();
+        let workspace_claim = store
+            .stage_workspace_deletion("w1", &["workspace-session".into()])
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.session_id == "workspace-session")
+            .unwrap();
+        store
+            .add_workspace("new", "S:/claim", "Ignored", "")
+            .unwrap();
+        assert!(store
+            .claim_deletions(&[workspace_claim.clone()])
+            .unwrap()
+            .is_empty());
+        store.confirm_deletions(&[workspace_claim]).unwrap();
+        assert_eq!(store.workspaces().unwrap().len(), 1);
         std::fs::remove_dir_all(dir).ok();
     }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -106,7 +106,8 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
             directory TEXT NOT NULL,
             workspace_id TEXT,
             queued_at INTEGER NOT NULL,
-            claim TEXT NOT NULL
+            claim TEXT NOT NULL,
+            claimed_at INTEGER
         ) STRICT;
         CREATE INDEX IF NOT EXISTS idx_pending_session_delete_workspace
             ON pending_session_delete(workspace_id);
@@ -143,6 +144,15 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
         "ALTER TABLE pending_session_delete ADD COLUMN claim TEXT NOT NULL DEFAULT ''",
         [],
     );
+    let _ = conn.execute(
+        "ALTER TABLE pending_session_delete ADD COLUMN claimed_at INTEGER",
+        [],
+    );
+    conn.execute(
+        "UPDATE pending_session_delete SET claim = ?1, claimed_at = NULL
+         WHERE claimed_at IS NOT NULL",
+        [deletion_claim()],
+    )?;
     Ok(Store(Mutex::new(conn)))
 }
 
@@ -172,7 +182,8 @@ fn workspace_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Workspace> {
 
 fn pending_deletions(conn: &Connection) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
     conn.prepare_cached(
-        "SELECT session_id, directory, claim FROM pending_session_delete ORDER BY queued_at, session_id",
+        "SELECT session_id, directory, claim FROM pending_session_delete
+         WHERE claimed_at IS NULL ORDER BY queued_at, session_id",
     )?
     .query_map([], |row| {
         Ok(PendingSessionDeletion {
@@ -341,6 +352,17 @@ impl Store {
             .optional()?;
         let target = match existing {
             Some(found) => {
+                let claimed: bool = tx.query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM pending_session_delete
+                        WHERE workspace_id = ?1 AND claimed_at IS NOT NULL
+                    )",
+                    [&found],
+                    |row| row.get(0),
+                )?;
+                if claimed {
+                    return Err(rusqlite::Error::InvalidQuery);
+                }
                 tx.prepare_cached(
                     "UPDATE workspace SET removed_at = NULL, purge_staged_at = NULL, last_used = ?2 WHERE id = ?1",
                 )?
@@ -421,6 +443,17 @@ impl Store {
     pub fn unarchive_session(&self, session_id: &str) -> rusqlite::Result<()> {
         let mut conn = self.0.lock().unwrap();
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        let claimed: bool = tx.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM pending_session_delete
+                WHERE session_id = ?1 AND claimed_at IS NOT NULL
+            )",
+            [session_id],
+            |row| row.get(0),
+        )?;
+        if claimed {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
         tx.prepare_cached("DELETE FROM session_meta WHERE session_id = ?1")?
             .execute([session_id])?;
         tx.prepare_cached("DELETE FROM pending_session_delete WHERE session_id = ?1")?
@@ -519,15 +552,25 @@ impl Store {
         &self,
         entries: &[PendingSessionDeletion],
     ) -> rusqlite::Result<Vec<PendingSessionDeletion>> {
-        let conn = self.0.lock().unwrap();
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
         let mut claimed = Vec::new();
         for entry in entries {
-            let current = conn
+            let claim = deletion_claim();
+            let changed = tx.execute(
+                "UPDATE pending_session_delete SET claim = ?3, claimed_at = ?4
+                 WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NULL",
+                params![entry.session_id, entry.claim, claim, now()],
+            )?;
+            if changed != 1 {
+                continue;
+            }
+            let current = tx
                 .prepare_cached(
                     "SELECT session_id, directory, claim FROM pending_session_delete
-                     WHERE session_id = ?1 AND claim = ?2",
+                     WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NOT NULL",
                 )?
-                .query_row(params![entry.session_id, entry.claim], |row| {
+                .query_row(params![entry.session_id, claim], |row| {
                     Ok(PendingSessionDeletion {
                         session_id: row.get(0)?,
                         directory: row.get(1)?,
@@ -539,7 +582,21 @@ impl Store {
                 claimed.push(current);
             }
         }
+        tx.commit()?;
         Ok(claimed)
+    }
+
+    pub fn release_deletions(&self, entries: &[PendingSessionDeletion]) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        for entry in entries {
+            tx.execute(
+                "UPDATE pending_session_delete SET claim = ?3, claimed_at = NULL
+                 WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NOT NULL",
+                params![entry.session_id, entry.claim, deletion_claim()],
+            )?;
+        }
+        tx.commit()
     }
 
     pub fn confirm_deletions(&self, entries: &[PendingSessionDeletion]) -> rusqlite::Result<()> {
@@ -547,7 +604,8 @@ impl Store {
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
         for entry in entries {
             let removed = tx.execute(
-                "DELETE FROM pending_session_delete WHERE session_id = ?1 AND claim = ?2",
+                "DELETE FROM pending_session_delete
+                 WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NOT NULL",
                 params![entry.session_id, entry.claim],
             )?;
             if removed == 1 {
@@ -784,9 +842,8 @@ mod tests {
         assert_eq!(sweep.pending.len(), 1);
         assert_eq!(sweep.pending[0].session_id, "s2");
         assert_eq!(store.archived().unwrap().len(), 1);
-        store
-            .confirm_deletions(&[sweep.pending[0].clone()])
-            .unwrap();
+        let claimed = store.claim_deletions(&sweep.pending).unwrap();
+        store.confirm_deletions(&[claimed[0].clone()]).unwrap();
         assert!(store.archived().unwrap().is_empty());
 
         store.remove_workspace("w1").unwrap();
@@ -811,7 +868,8 @@ mod tests {
             .into_iter()
             .find(|entry| entry.session_id == "old-session")
             .unwrap();
-        store.confirm_deletions(&[old_session]).unwrap();
+        let claimed = store.claim_deletions(&[old_session]).unwrap();
+        store.confirm_deletions(&claimed).unwrap();
         assert!(store.workspaces().unwrap().is_empty());
         assert!(
             store
@@ -910,7 +968,8 @@ mod tests {
                 .into_iter()
                 .find(|entry| entry.session_id == "archived")
                 .unwrap();
-            store.confirm_deletions(&[archived]).unwrap();
+            let claimed = store.claim_deletions(&[archived]).unwrap();
+            store.confirm_deletions(&claimed).unwrap();
             assert_eq!(store.removed_workspaces().unwrap().len(), 1);
         }
         {
@@ -949,10 +1008,10 @@ mod tests {
         assert_ne!(stale.claim, replacement.claim);
         store.confirm_deletions(&[stale]).unwrap();
         assert_eq!(store.archived().unwrap().len(), 1);
-        assert_eq!(
-            store.claim_deletions(&[replacement.clone()]).unwrap()[0].claim,
-            replacement.claim
-        );
+        let active = store.claim_deletions(&[replacement]).unwrap()[0].clone();
+        assert!(store.unarchive_session("session").is_err());
+        store.release_deletions(&[active]).unwrap();
+        store.unarchive_session("session").unwrap();
 
         store.remove_workspace("w1").unwrap();
         let workspace_claim = store
@@ -961,6 +1020,12 @@ mod tests {
             .into_iter()
             .find(|entry| entry.session_id == "workspace-session")
             .unwrap();
+        let active_workspace =
+            store.claim_deletions(&[workspace_claim.clone()]).unwrap()[0].clone();
+        assert!(store
+            .add_workspace("new", "S:/claim", "Ignored", "")
+            .is_err());
+        store.release_deletions(&[active_workspace]).unwrap();
         store
             .add_workspace("new", "S:/claim", "Ignored", "")
             .unwrap();

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -156,6 +156,10 @@ fn open_at(file: &Path) -> rusqlite::Result<Store> {
     Ok(Store(Mutex::new(conn)))
 }
 
+/// A claim held longer than this is treated as abandoned: the sweep holding it died or was pinned by a
+/// hung engine request. Must stay above the engine sweep budget so a live sweep keeps its own claims.
+const CLAIM_DEADLINE: i64 = 5 * 60 * 1000;
+
 fn now() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -355,9 +359,9 @@ impl Store {
                 let claimed: bool = tx.query_row(
                     "SELECT EXISTS(
                         SELECT 1 FROM pending_session_delete
-                        WHERE workspace_id = ?1 AND claimed_at IS NOT NULL
+                        WHERE workspace_id = ?1 AND claimed_at IS NOT NULL AND claimed_at > ?2
                     )",
-                    [&found],
+                    params![&found, now() - CLAIM_DEADLINE],
                     |row| row.get(0),
                 )?;
                 if claimed {
@@ -446,9 +450,9 @@ impl Store {
         let claimed: bool = tx.query_row(
             "SELECT EXISTS(
                 SELECT 1 FROM pending_session_delete
-                WHERE session_id = ?1 AND claimed_at IS NOT NULL
+                WHERE session_id = ?1 AND claimed_at IS NOT NULL AND claimed_at > ?2
             )",
-            [session_id],
+            params![session_id, now() - CLAIM_DEADLINE],
             |row| row.get(0),
         )?;
         if claimed {
@@ -484,6 +488,13 @@ impl Store {
         tx.execute(
             "UPDATE pending_session_delete SET claim = ?1 WHERE claim = ''",
             [deletion_claim()],
+        )?;
+        // Rotate abandoned claims back into the queue so a hung delete cannot block restores or later
+        // sweeps until the next app start. The rotation invalidates the old holder's claim.
+        tx.execute(
+            "UPDATE pending_session_delete SET claim = ?1, claimed_at = NULL
+             WHERE claimed_at IS NOT NULL AND claimed_at <= ?2",
+            params![deletion_claim(), now() - CLAIM_DEADLINE],
         )?;
         let pending = pending_deletions(&tx)?;
         let workspaces = tx
@@ -1110,6 +1121,55 @@ mod tests {
         assert_eq!(pending[0].session_id, "retry");
         assert_ne!(pending[0].claim, retry.claim);
         assert!(store.claim_deletions(&[retry]).unwrap().is_empty());
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn abandoned_deletion_claims_expire_without_an_app_restart() {
+        let dir = std::env::temp_dir().join(format!("drift-deadline-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = open_at(&dir.join("drift.db")).unwrap();
+        store
+            .add_workspace("w1", "S:/deadline", "Deadline", "")
+            .unwrap();
+        store.archive_session("hung", "w1").unwrap();
+
+        let pending = store.prepare_deletions(now() + 1000).unwrap().pending;
+        let hung = store.claim_deletions(&pending).unwrap()[0].clone();
+        // A live claim still blocks restores and is not handed to another sweep.
+        assert!(store.unarchive_session("hung").is_err());
+        assert!(store
+            .prepare_deletions(now() + 1000)
+            .unwrap()
+            .pending
+            .is_empty());
+
+        // Simulate the holder hanging past the deadline instead of restarting the app.
+        store
+            .0
+            .lock()
+            .unwrap()
+            .execute(
+                "UPDATE pending_session_delete SET claimed_at = ?1",
+                [now() - CLAIM_DEADLINE - 1],
+            )
+            .unwrap();
+
+        let requeued = store.prepare_deletions(now() + 1000).unwrap().pending;
+        assert_eq!(requeued.len(), 1);
+        assert_eq!(requeued[0].session_id, "hung");
+        // The abandoned claim is rotated, so the hung holder can no longer confirm the deletion.
+        assert_ne!(requeued[0].claim, hung.claim);
+        assert!(store.claim_deletions(&[hung.clone()]).unwrap().is_empty());
+        store.confirm_deletions(&[hung]).unwrap();
+        assert_eq!(store.archived().unwrap().len(), 1);
+
+        // A later sweep re-verifies the exact ID, and restores work again once nothing holds a claim.
+        let active = store.claim_deletions(&[requeued[0].clone()]).unwrap()[0].clone();
+        assert!(store.unarchive_session("hung").is_err());
+        store.release_deletions(&[active]).unwrap();
+        store.unarchive_session("hung").unwrap();
         std::fs::remove_dir_all(dir).ok();
     }
 

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -626,6 +626,44 @@ impl Store {
         tx.commit()
     }
 
+    pub fn finalize_deletions(
+        &self,
+        confirmed: &[PendingSessionDeletion],
+        retry: &[PendingSessionDeletion],
+    ) -> rusqlite::Result<()> {
+        let mut conn = self.0.lock().unwrap();
+        let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        for entry in retry {
+            tx.execute(
+                "UPDATE pending_session_delete SET claim = ?3, claimed_at = NULL
+                 WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NOT NULL",
+                params![entry.session_id, entry.claim, deletion_claim()],
+            )?;
+        }
+        for entry in confirmed {
+            let removed = tx.execute(
+                "DELETE FROM pending_session_delete
+                 WHERE session_id = ?1 AND claim = ?2 AND claimed_at IS NOT NULL",
+                params![entry.session_id, entry.claim],
+            )?;
+            if removed == 1 {
+                tx.execute(
+                    "DELETE FROM session_meta WHERE session_id = ?1",
+                    [&entry.session_id],
+                )?;
+            }
+        }
+        tx.execute(
+            "DELETE FROM workspace
+             WHERE removed_at IS NOT NULL AND purge_staged_at IS NOT NULL
+               AND NOT EXISTS (
+                   SELECT 1 FROM pending_session_delete pending WHERE pending.workspace_id = workspace.id
+               )",
+            [],
+        )?;
+        tx.commit()
+    }
+
     pub fn mcp_state(&self) -> rusqlite::Result<McpState> {
         let conn = self.0.lock().unwrap();
         let generation =
@@ -1035,6 +1073,43 @@ mod tests {
             .is_empty());
         store.confirm_deletions(&[workspace_claim]).unwrap();
         assert_eq!(store.workspaces().unwrap().len(), 1);
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn deletion_finalization_confirms_and_rotates_exact_claims_together() {
+        let dir = std::env::temp_dir().join(format!("drift-finalize-test-{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = open_at(&dir.join("drift.db")).unwrap();
+        store
+            .add_workspace("w1", "S:/finalize", "Finalize", "")
+            .unwrap();
+        store.archive_session("confirmed", "w1").unwrap();
+        store.archive_session("retry", "w1").unwrap();
+        let pending = store.prepare_deletions(now() + 1000).unwrap().pending;
+        let claimed = store.claim_deletions(&pending).unwrap();
+        let confirmed = claimed
+            .iter()
+            .find(|entry| entry.session_id == "confirmed")
+            .unwrap()
+            .clone();
+        let retry = claimed
+            .iter()
+            .find(|entry| entry.session_id == "retry")
+            .unwrap()
+            .clone();
+
+        store
+            .finalize_deletions(&[confirmed], &[retry.clone()])
+            .unwrap();
+
+        assert_eq!(store.archived().unwrap()[0].session_id, "retry");
+        let pending = store.prepare_deletions(now() + 1000).unwrap().pending;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].session_id, "retry");
+        assert_ne!(pending[0].claim, retry.claim);
+        assert!(store.claim_deletions(&[retry]).unwrap().is_empty());
         std::fs::remove_dir_all(dir).ok();
     }
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,6 +13,7 @@ import {
   initWorkspaces,
   confirmDeletions,
   claimDeletions,
+  releaseDeletions,
   prepareDeletions,
   purgeAge,
   stageWorkspaceDeletion,
@@ -157,6 +158,8 @@ function WorkspaceBinding() {
       }
       const claimed = await claimDeletions(sweep.pending)
       const confirmed = await engine.actions.removePendingSessions(claimed)
+      const confirmedClaims = new Set(confirmed.map((entry) => entry.claim))
+      await releaseDeletions(claimed.filter((entry) => !confirmedClaims.has(entry.claim)))
       await confirmDeletions(confirmed)
     })()
       .catch(() => undefined)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,7 +11,7 @@ import { initZoom } from "./state/zoom"
 import {
   activeWorkspace,
   initWorkspaces,
-  confirmDeletions,
+  finalizeDeletions,
   claimDeletions,
   releaseDeletions,
   prepareDeletions,
@@ -158,9 +158,14 @@ function WorkspaceBinding() {
       }
       const claimed = await claimDeletions(sweep.pending)
       const confirmed = await engine.actions.removePendingSessions(claimed)
-      const confirmedClaims = new Set(confirmed.map((entry) => entry.claim))
-      await releaseDeletions(claimed.filter((entry) => !confirmedClaims.has(entry.claim)))
-      await confirmDeletions(confirmed)
+      const confirmedClaims = new Set(confirmed.map((entry) => `${entry.sessionId}\0${entry.claim}`))
+      const retry = claimed.filter((entry) => !confirmedClaims.has(`${entry.sessionId}\0${entry.claim}`))
+      try {
+        await finalizeDeletions(confirmed, retry)
+      } catch (error) {
+        await releaseDeletions(claimed)
+        throw error
+      }
     })()
       .catch(() => undefined)
       .finally(() => (purging = false))

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -157,13 +157,13 @@ function WorkspaceBinding() {
         sweep = { ...sweep, pending: await stageWorkspaceDeletion(workspace.id, ids) }
       }
       const claimed = await claimDeletions(sweep.pending)
-      const confirmed = await engine.actions.removePendingSessions(claimed)
-      const confirmedClaims = new Set(confirmed.map((entry) => `${entry.sessionId}\0${entry.claim}`))
-      const retry = claimed.filter((entry) => !confirmedClaims.has(`${entry.sessionId}\0${entry.claim}`))
+      // Timed-out entries are in neither list: they keep their claim so a delete that is still running
+      // server-side cannot be undone by a restore, and the store's claim deadline re-sweeps them.
+      const { confirmed, retry } = await engine.actions.removePendingSessions(claimed)
       try {
         await finalizeDeletions(confirmed, retry)
       } catch (error) {
-        await releaseDeletions(claimed)
+        await releaseDeletions(retry)
         throw error
       }
     })()

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,8 +11,10 @@ import { initZoom } from "./state/zoom"
 import {
   activeWorkspace,
   initWorkspaces,
-  purgeArchived,
-  purgeRemovedWorkspaces,
+  confirmDeletions,
+  prepareDeletions,
+  purgeAge,
+  stageWorkspaceDeletion,
   workspaces,
 } from "./state/workspaces"
 import { AttentionStrip } from "./ui/attention"
@@ -106,11 +108,9 @@ function PluginBinding() {
   )
 }
 
-const dayMs = 24 * 60 * 60 * 1000
-
 function WorkspaceBinding() {
   const engine = useEngine()
-  let lastPurge = 0
+  let purging = false
   let permissionTick = 0
   onMount(() => void initWorkspaces())
   createEffect(() => engine.setDirectory(activeWorkspace()?.path ?? null))
@@ -145,9 +145,19 @@ function WorkspaceBinding() {
   }
 
   function purge() {
-    if (engine.state.connection !== "online" || Date.now() - lastPurge < dayMs) return
-    lastPurge = Date.now()
-    void purgeArchived().then((ids) => ids.forEach((id) => void engine.actions.remove(id)))
-    void purgeRemovedWorkspaces().then((paths) => paths.forEach((path) => void engine.actions.removeAllSessions(path)))
+    if (engine.state.connection !== "online" || purging) return
+    purging = true
+    void (async () => {
+      let sweep = await prepareDeletions(Date.now() - purgeAge)
+      for (const workspace of sweep.workspaces) {
+        const ids = await engine.actions.sessionIdsAt(workspace.path)
+        if (!ids) continue
+        sweep = { ...sweep, pending: await stageWorkspaceDeletion(workspace.id, ids) }
+      }
+      const confirmed = await engine.actions.removePendingSessions(sweep.pending)
+      await confirmDeletions(confirmed)
+    })()
+      .catch(() => undefined)
+      .finally(() => (purging = false))
   }
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,7 @@ import {
   activeWorkspace,
   initWorkspaces,
   confirmDeletions,
+  claimDeletions,
   prepareDeletions,
   purgeAge,
   stageWorkspaceDeletion,
@@ -154,7 +155,8 @@ function WorkspaceBinding() {
         if (!ids) continue
         sweep = { ...sweep, pending: await stageWorkspaceDeletion(workspace.id, ids) }
       }
-      const confirmed = await engine.actions.removePendingSessions(sweep.pending)
+      const claimed = await claimDeletions(sweep.pending)
+      const confirmed = await engine.actions.removePendingSessions(claimed)
       await confirmDeletions(confirmed)
     })()
       .catch(() => undefined)

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -28,7 +28,7 @@ export type PromptOptions = { model: ModelRef | null; agent: string; variant?: s
 export type PermissionResponse = "once" | "always" | "reject"
 export type ProviderAuthResult = { ok: boolean; connected: boolean }
 export type SessionMoveResult = { ok: boolean; moved: string[]; error?: string }
-export type PendingSessionDeletion = { sessionId: string; directory: string }
+export type PendingSessionDeletion = { sessionId: string; directory: string; claim: string }
 
 type PermissionRequest = {
   id: string
@@ -122,15 +122,8 @@ export function createActions(
     if (!base) return
     if (allSessionsRequest) return allSessionsRequest
     allSessionsRequest = (async () => {
-      const query = new URLSearchParams({ archived: "true", limit: "10000" })
-      const headers = {
-        ...base.headers,
-        ...(state.directory ? { "x-opencode-directory": encodeURIComponent(state.directory) } : {}),
-      }
-      const response = await fetch(`${base.url}/experimental/session?${query}`, { headers }).catch(() => null)
-      if (!response?.ok) return
-      const sessions = (await response.json().catch(() => null)) as Session[] | null
-      putSessions(set, sessions ?? [])
+      const sessions = await experimentalSessions()
+      if (sessions) putSessions(set, sessions)
     })()
     try {
       await allSessionsRequest
@@ -217,13 +210,33 @@ export function createActions(
     return spawned
   }
 
-  async function sessionsAt(directory: string): Promise<Session[] | null> {
+  async function experimentalSessions(directory?: string): Promise<Session[] | null> {
     const base = target()
     if (!base) return null
-    const query = new URLSearchParams({ directory, archived: "true", limit: "10000" })
-    const response = await fetch(`${base.url}/experimental/session?${query}`, { headers: base.headers }).catch(() => null)
-    if (!response?.ok) return null
-    return (await response.json().catch(() => null)) as Session[] | null
+    const sessions: Session[] = []
+    const cursors = new Set<string>()
+    let cursor: string | undefined
+    for (;;) {
+      const query = new URLSearchParams({ archived: "true", limit: "100" })
+      if (directory) query.set("directory", directory)
+      if (cursor) query.set("cursor", cursor)
+      const response = await fetch(`${base.url}/experimental/session?${query}`, { headers: base.headers }).catch(
+        () => null,
+      )
+      if (!response?.ok) return null
+      const page = (await response.json().catch(() => null)) as Session[] | null
+      if (!page) return null
+      sessions.push(...page)
+      const next = response.headers.get("x-next-cursor") ?? undefined
+      if (!next) return sessions
+      if (cursors.has(next)) return null
+      cursors.add(next)
+      cursor = next
+    }
+  }
+
+  async function sessionsAt(directory: string): Promise<Session[] | null> {
+    return experimentalSessions(directory)
   }
 
   async function sessionIdsAt(directory: string): Promise<string[] | null> {
@@ -235,15 +248,15 @@ export function createActions(
     const base = target()
     if (!base) return []
     const confirmed: PendingSessionDeletion[] = []
-    const clients = new Map<string, OpencodeClient>()
     for (const entry of entries) {
-      let client = clients.get(entry.directory)
-      if (!client) {
-        client = createOpencodeClient({ baseUrl: base.url, headers: base.headers, directory: entry.directory })
-        clients.set(entry.directory, client)
+      const url = `${base.url}/session/${encodeURIComponent(entry.sessionId)}?directory=${encodeURIComponent(entry.directory)}`
+      const removed = await fetch(url, { method: "DELETE", headers: base.headers }).catch(() => null)
+      if (!removed) continue
+      if (removed.status !== 404) {
+        if (!removed.ok) continue
+        const exact = await fetch(url, { headers: base.headers }).catch(() => null)
+        if (exact?.status !== 404) continue
       }
-      const result = await client.session.delete({ path: { id: entry.sessionId } }).catch(() => null)
-      if (!result || (result.error && result.response?.status !== 404)) continue
       confirmed.push(entry)
       forgetSession(entry.sessionId)
     }
@@ -293,10 +306,27 @@ export function createActions(
     for (const session of moving) {
       const error = await rebindSession(session.id, session.directory, destination)
       if (error) {
-        for (const rollback of completed.reverse()) await rebindSession(rollback.id, destination, rollback.directory)
-        const restored = await sessionsAt(moving[0].directory)
-        for (const info of restored ?? []) putSession(set, info)
-        return { ok: false, moved: [], error }
+        const rollbackFailures = new Map<string, string>()
+        for (const rollback of completed.reverse()) {
+          const rollbackError = await rebindSession(rollback.id, destination, rollback.directory)
+          if (rollbackError) rollbackFailures.set(rollback.id, rollbackError)
+          else putSession(set, { ...rollback, directory: rollback.directory })
+        }
+
+        const movedIds = new Set(moving.map((entry) => entry.id))
+        for (const directory of new Set([...moving.map((entry) => entry.directory), destination])) {
+          const refreshed = await sessionsAt(directory)
+          for (const info of refreshed ?? []) if (movedIds.has(info.id)) putSession(set, info)
+        }
+        const stillMoved = completed
+          .filter((entry) => normalizeDir(state.sessions[entry.id]?.directory ?? destination) === normalizeDir(destination))
+          .map((entry) => entry.id)
+        const details = [
+          error,
+          rollbackFailures.size ? `Rollback failed for ${[...rollbackFailures.keys()].join(", ")}` : "",
+          stillMoved.length ? `Still moved: ${stillMoved.join(", ")}` : "",
+        ].filter(Boolean)
+        return { ok: false, moved: stillMoved, error: details.join(". ") }
       }
       completed.push(session)
       putSession(set, { ...session, directory: destination })

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -30,6 +30,34 @@ export type PermissionResponse = "once" | "always" | "reject"
 export type ProviderAuthResult = { ok: boolean; connected: boolean }
 export type SessionMoveResult = { ok: boolean; moved: string[]; error?: string }
 export type PendingSessionDeletion = { sessionId: string; directory: string; claim: string }
+/**
+ * `confirmed` is safe to erase, `retry` is safe to unclaim. Entries in neither list timed out: the
+ * engine may still be deleting them, so their claim must stay held until a later sweep re-verifies.
+ */
+export type PendingDeletionResult = { confirmed: PendingSessionDeletion[]; retry: PendingSessionDeletion[] }
+
+/** Bounds one request and a whole sweep, so a hung engine cannot pin claims past the store's claim
+ * deadline. Both must stay well under that deadline or a live sweep would lose its own claims. */
+export type DeletionDeadlines = { request: number; sweep: number }
+const deletionDeadlines: DeletionDeadlines = { request: 15000, sweep: 60000 }
+
+type DeadlineResponse = { ok: true; response: Response } | { ok: false; timedOut: boolean }
+
+async function requestWithDeadline(url: string, init: RequestInit, timeout: number): Promise<DeadlineResponse> {
+  const controller = new AbortController()
+  let timedOut = false
+  const timer = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeout)
+  try {
+    return { ok: true, response: await fetch(url, { ...init, signal: controller.signal }) }
+  } catch {
+    return { ok: false, timedOut }
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
 type PermissionRequest = {
   id: string
@@ -267,23 +295,45 @@ export function createActions(
     return sessions?.map((session) => session.id) ?? null
   }
 
-  async function removePendingSessions(entries: PendingSessionDeletion[]): Promise<PendingSessionDeletion[]> {
+  async function removePendingSessions(
+    entries: PendingSessionDeletion[],
+    deadlines: DeletionDeadlines = deletionDeadlines,
+  ): Promise<PendingDeletionResult> {
     const base = target()
-    if (!base) return []
+    if (!base) return { confirmed: [], retry: entries }
     const confirmed: PendingSessionDeletion[] = []
+    const retry: PendingSessionDeletion[] = []
+    const sweepDeadline = Date.now() + deadlines.sweep
     for (const entry of entries) {
+      // Never touched the engine, so unclaiming cannot race a server-side delete.
+      if (Date.now() >= sweepDeadline) {
+        retry.push(entry)
+        continue
+      }
       const url = `${base.url}/session/${encodeURIComponent(entry.sessionId)}?directory=${encodeURIComponent(entry.directory)}`
-      const removed = await fetch(url, { method: "DELETE", headers: base.headers }).catch(() => null)
-      if (!removed) continue
-      if (removed.status !== 404) {
-        if (!removed.ok) continue
-        const exact = await fetch(url, { headers: base.headers }).catch(() => null)
-        if (exact?.status !== 404) continue
+      const removed = await requestWithDeadline(url, { method: "DELETE", headers: base.headers }, deadlines.request)
+      if (!removed.ok) {
+        // A timed-out delete may still land, so hold the claim and re-verify this exact ID later.
+        if (!removed.timedOut) retry.push(entry)
+        continue
+      }
+      if (removed.response.status !== 404) {
+        if (!removed.response.ok) {
+          retry.push(entry)
+          continue
+        }
+        const exact = await requestWithDeadline(url, { headers: base.headers }, deadlines.request)
+        if (!exact.ok) {
+          if (!exact.timedOut) retry.push(entry)
+          continue
+        }
+        // Accepted but still present: the engine may be finishing the delete, so hold the claim too.
+        if (exact.response.status !== 404) continue
       }
       confirmed.push(entry)
       forgetSession(entry.sessionId)
     }
-    return confirmed
+    return { confirmed, retry }
   }
 
   async function rebindSession(id: string, source: string, destination: string): Promise<string | null> {

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -28,6 +28,7 @@ export type PromptOptions = { model: ModelRef | null; agent: string; variant?: s
 export type PermissionResponse = "once" | "always" | "reject"
 export type ProviderAuthResult = { ok: boolean; connected: boolean }
 export type SessionMoveResult = { ok: boolean; moved: string[]; error?: string }
+export type PendingSessionDeletion = { sessionId: string; directory: string }
 
 type PermissionRequest = {
   id: string
@@ -138,13 +139,6 @@ export function createActions(
     }
   }
 
-  async function removeAllSessions(directory: string) {
-    const result = await requireClient().session.list({ query: { directory } })
-    for (const session of result.data ?? []) {
-      await requireClient().session.delete({ path: { id: session.id }, query: { directory } })
-    }
-  }
-
   async function newSession(): Promise<Session | undefined> {
     const result = await requireClient().session.create({ body: {} })
     if (result.data) set("sessions", result.data.id, result.data)
@@ -232,12 +226,40 @@ export function createActions(
     return (await response.json().catch(() => null)) as Session[] | null
   }
 
-  async function rebindSession(id: string, destination: string): Promise<string | null> {
+  async function sessionIdsAt(directory: string): Promise<string[] | null> {
+    const sessions = await sessionsAt(directory)
+    return sessions?.map((session) => session.id) ?? null
+  }
+
+  async function removePendingSessions(entries: PendingSessionDeletion[]): Promise<PendingSessionDeletion[]> {
+    const base = target()
+    if (!base) return []
+    const confirmed: PendingSessionDeletion[] = []
+    const clients = new Map<string, OpencodeClient>()
+    for (const entry of entries) {
+      let client = clients.get(entry.directory)
+      if (!client) {
+        client = createOpencodeClient({ baseUrl: base.url, headers: base.headers, directory: entry.directory })
+        clients.set(entry.directory, client)
+      }
+      const result = await client.session.delete({ path: { id: entry.sessionId } }).catch(() => null)
+      if (!result || (result.error && result.response?.status !== 404)) continue
+      confirmed.push(entry)
+      forgetSession(entry.sessionId)
+    }
+    return confirmed
+  }
+
+  async function rebindSession(id: string, source: string, destination: string): Promise<string | null> {
     const base = target()
     if (!base) return "Engine is offline"
     const response = await fetch(`${base.url}/experimental/control-plane/move-session`, {
       method: "POST",
-      headers: { "content-type": "application/json", ...base.headers },
+      headers: {
+        "content-type": "application/json",
+        "x-opencode-directory": encodeURIComponent(source),
+        ...base.headers,
+      },
       body: JSON.stringify({ sessionID: id, destination: { directory: destination }, moveChanges: false }),
     }).catch(() => null)
     if (!response) return "Could not reach the engine"
@@ -249,13 +271,29 @@ export function createActions(
   async function moveSessions(entries: Session[], destination: string): Promise<SessionMoveResult> {
     const moving = entries.filter((session) => normalizeDir(session.directory) !== normalizeDir(destination))
     if (!moving.length) return { ok: true, moved: [] }
-    for (const session of moving) await interrupt(session.id)
+    for (const session of moving) {
+      if (await interrupt(session.id)) continue
+      return { ok: false, moved: [], error: `Session ${session.title || session.id} is still active` }
+    }
+    for (const directory of new Set(moving.map((session) => session.directory))) {
+      const base = target()
+      if (!base) return { ok: false, moved: [], error: "Engine is offline" }
+      const response = await fetch(`${base.url}/session/status?directory=${encodeURIComponent(directory)}`, {
+        headers: base.headers,
+      }).catch(() => null)
+      const statuses = response?.ok
+        ? ((await response.json().catch(() => null)) as Record<string, { type: string }> | null)
+        : null
+      if (!statuses) return { ok: false, moved: [], error: "Could not confirm that the session tree is idle" }
+      const active = moving.find((session) => session.directory === directory && statuses[session.id]?.type !== undefined)
+      if (active) return { ok: false, moved: [], error: `Session ${active.title || active.id} is still active` }
+    }
 
     const completed: Session[] = []
     for (const session of moving) {
-      const error = await rebindSession(session.id, destination)
+      const error = await rebindSession(session.id, session.directory, destination)
       if (error) {
-        for (const rollback of completed.reverse()) await rebindSession(rollback.id, rollback.directory)
+        for (const rollback of completed.reverse()) await rebindSession(rollback.id, destination, rollback.directory)
         const restored = await sessionsAt(moving[0].directory)
         for (const info of restored ?? []) putSession(set, info)
         return { ok: false, moved: [], error }
@@ -434,7 +472,8 @@ export function createActions(
   }
 
   async function remove(id: string) {
-    await requireClient().session.delete({ path: { id } })
+    const result = await requireClient().session.delete({ path: { id } })
+    if (result.error) throw new Error("The engine rejected the session deletion")
     forgetSession(id)
   }
 
@@ -579,13 +618,17 @@ export function createActions(
     for (const permission of state.permissions[id] ?? [])
       await replyPermission(id, permission.id, "reject").catch(() => {})
     for (const question of state.questions[id] ?? []) await answerQuestion(id, question.id, null)
-    if (!sessionBusy(state, id)) return
-    await requireClient().session.abort({ path: { id } }).catch(() => {})
+    if (!sessionBusy(state, id)) return true
+    const result = await requireClient()
+      .session.abort({ path: { id } })
+      .catch(() => null)
+    if (!result || result.error) return false
     for (let waited = 0; waited < 5000 && sessionBusy(state, id); waited += 100) await sleep(100)
+    return !sessionBusy(state, id)
   }
 
   async function revert(id: string, messageID: string) {
-    await interrupt(id)
+    if (!(await interrupt(id))) return false
     const result = await requireClient().session.revert({ path: { id }, body: { messageID } })
     if (result.error) {
       set("errors", id, "Revert failed: the engine rejected the request")
@@ -598,7 +641,7 @@ export function createActions(
   }
 
   async function unrevert(id: string) {
-    await interrupt(id)
+    if (!(await interrupt(id))) return false
     const result = await requireClient().session.unrevert({ path: { id } })
     if (!result.data) return false
     putSession(set, result.data)
@@ -622,7 +665,8 @@ export function createActions(
     loadOlder,
     loadSessions,
     loadAllSessions,
-    removeAllSessions,
+    sessionIdsAt,
+    removePendingSessions,
     newSession,
     fork,
     spawn,

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -216,10 +216,12 @@ export function createActions(
     const sessions: Session[] = []
     const cursors = new Set<string>()
     let cursor: string | undefined
+    let cursorID: string | undefined
     for (;;) {
       const query = new URLSearchParams({ archived: "true", limit: "100" })
       if (directory) query.set("directory", directory)
       if (cursor) query.set("cursor", cursor)
+      if (cursorID) query.set("cursorID", cursorID)
       const response = await fetch(`${base.url}/experimental/session?${query}`, { headers: base.headers }).catch(
         () => null,
       )
@@ -228,10 +230,13 @@ export function createActions(
       if (!page) return null
       sessions.push(...page)
       const next = response.headers.get("x-next-cursor") ?? undefined
+      const nextID = response.headers.get("x-next-cursor-id") ?? undefined
       if (!next) return sessions
-      if (cursors.has(next)) return null
-      cursors.add(next)
+      const key = `${next}\0${nextID ?? ""}`
+      if (cursors.has(key)) return null
+      cursors.add(key)
       cursor = next
+      cursorID = nextID
     }
   }
 

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -76,8 +76,10 @@ export function EngineProvider(props: ParentProps) {
     set("cursors", id, result.response?.headers?.get("x-next-cursor") ?? null)
   }
 
-  async function pump(target: EngineTarget, signal: AbortSignal) {
+  async function pump(signal: AbortSignal) {
     while (!signal.aborted) {
+      const target = base
+      if (!target) return
       try {
         await streamEvents(target, signal, (event, eventDirectory) => {
           if (event.type === "server.connected") {
@@ -90,9 +92,22 @@ export function EngineProvider(props: ParentProps) {
       } catch {}
       if (signal.aborted) return
       set("connection", "offline")
-      await sleep(1500)
+      await sleep(300)
       if (signal.aborted) return
       set("connection", "connecting")
+      try {
+        const refreshed = await resolveEngine()
+        if (signal.aborted || disposed) return
+        base = refreshed
+        if (directory)
+          client = createOpencodeClient({ baseUrl: refreshed.url, headers: refreshed.headers, directory })
+        set("startupError", "")
+      } catch (error) {
+        if (signal.aborted || disposed) return
+        set("startupError", error instanceof Error ? error.message : String(error))
+        set("connection", "offline")
+        return
+      }
     }
   }
 
@@ -115,7 +130,7 @@ export function EngineProvider(props: ParentProps) {
     )
     if (import.meta.env.DEV) seedBench(set, path)
     pumpAbort = new AbortController()
-    void pump(base, pumpAbort.signal)
+    void pump(pumpAbort.signal)
   }
 
   function setDirectory(path: string | null) {
@@ -146,6 +161,7 @@ export function EngineProvider(props: ParentProps) {
   void resolveEngine()
     .then(async (target) => {
       base = target
+      set("startupError", "")
       const health = await fetch(`${target.url}/global/health`, { headers: target.headers })
         .then((response) => (response.ok ? (response.json() as Promise<{ version?: string }>) : null))
         .catch(() => null)

--- a/src/i18n/ar.ts
+++ b/src/i18n/ar.ts
@@ -1059,6 +1059,7 @@ export const drift = {
   "drift.archive.deletesSoon": "سيُحذف قريبًا",
   "drift.archive.empty": "لا توجد عناصر مؤرشفة.",
   "drift.archive.retention": "تُزال العناصر نهائيًا بعد سبعة أيام.",
+  "drift.archive.restoreFailed": "تعذر استعادة العنصر",
   "drift.archive.threads": "المحادثات",
   "drift.archive.unknownWorkspace": "مساحة عمل غير معروفة",
   "drift.attachment.download": "تنزيل",

--- a/src/i18n/br.ts
+++ b/src/i18n/br.ts
@@ -1075,6 +1075,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Exclusão em breve",
   "drift.archive.empty": "Nada arquivado.",
   "drift.archive.retention": "Os itens são removidos permanentemente após sete dias.",
+  "drift.archive.restoreFailed": "Não foi possível restaurar o item",
   "drift.archive.threads": "Conversas",
   "drift.archive.unknownWorkspace": "Espaço de trabalho desconhecido",
   "drift.attachment.download": "Baixar",

--- a/src/i18n/bs.ts
+++ b/src/i18n/bs.ts
@@ -1151,6 +1151,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Uskoro se briše",
   "drift.archive.empty": "Arhiva je prazna.",
   "drift.archive.retention": "Stavke se trajno uklanjaju nakon sedam dana.",
+  "drift.archive.restoreFailed": "Nije moguće vratiti stavku",
   "drift.archive.threads": "Razgovori",
   "drift.archive.unknownWorkspace": "Nepoznat radni prostor",
   "drift.attachment.download": "Preuzmi",

--- a/src/i18n/da.ts
+++ b/src/i18n/da.ts
@@ -1143,6 +1143,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Slettes snart",
   "drift.archive.empty": "Intet arkiveret.",
   "drift.archive.retention": "Elementer fjernes permanent efter syv dage.",
+  "drift.archive.restoreFailed": "Elementet kunne ikke gendannes",
   "drift.archive.threads": "Tråde",
   "drift.archive.unknownWorkspace": "Ukendt arbejdsområde",
   "drift.attachment.download": "Download",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1084,6 +1084,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Wird bald gelöscht",
   "drift.archive.empty": "Nichts archiviert.",
   "drift.archive.retention": "Elemente werden nach sieben Tagen dauerhaft entfernt.",
+  "drift.archive.restoreFailed": "Element konnte nicht wiederhergestellt werden",
   "drift.archive.threads": "Threads",
   "drift.archive.unknownWorkspace": "Unbekannter Arbeitsbereich",
   "drift.attachment.download": "Herunterladen",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -316,6 +316,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Deletes soon",
   "drift.archive.empty": "Nothing archived.",
   "drift.archive.retention": "Items are permanently removed after seven days.",
+  "drift.archive.restoreFailed": "Could not restore item",
   "drift.archive.threads": "Threads",
   "drift.archive.unknownWorkspace": "Unknown workspace",
   "drift.attachment.download": "Download",

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1158,6 +1158,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Se elimina pronto",
   "drift.archive.empty": "No hay nada archivado.",
   "drift.archive.retention": "Los elementos se eliminan permanentemente después de siete días.",
+  "drift.archive.restoreFailed": "No se pudo restaurar el elemento",
   "drift.archive.threads": "Hilos",
   "drift.archive.unknownWorkspace": "Espacio de trabajo desconocido",
   "drift.attachment.download": "Descargar",

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -1090,6 +1090,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Suppression imminente",
   "drift.archive.empty": "Aucun élément archivé.",
   "drift.archive.retention": "Les éléments sont supprimés définitivement après sept jours.",
+  "drift.archive.restoreFailed": "Impossible de restaurer l'élément",
   "drift.archive.threads": "Discussions",
   "drift.archive.unknownWorkspace": "Espace de travail inconnu",
   "drift.attachment.download": "Télécharger",

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -1068,6 +1068,7 @@ export const drift = {
   "drift.archive.deletesSoon": "まもなく削除",
   "drift.archive.empty": "アーカイブされた項目はありません。",
   "drift.archive.retention": "項目は7日後に完全に削除されます。",
+  "drift.archive.restoreFailed": "項目を復元できませんでした",
   "drift.archive.threads": "スレッド",
   "drift.archive.unknownWorkspace": "不明なワークスペース",
   "drift.attachment.download": "ダウンロード",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1066,6 +1066,7 @@ export const drift = {
   "drift.archive.deletesSoon": "곧 삭제됨",
   "drift.archive.empty": "보관된 항목이 없습니다.",
   "drift.archive.retention": "항목은 7일 후 영구 삭제됩니다.",
+  "drift.archive.restoreFailed": "항목을 복원할 수 없습니다",
   "drift.archive.threads": "스레드",
   "drift.archive.unknownWorkspace": "알 수 없는 작업 공간",
   "drift.attachment.download": "다운로드",

--- a/src/i18n/no.ts
+++ b/src/i18n/no.ts
@@ -1160,6 +1160,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Slettes snart",
   "drift.archive.empty": "Ingenting er arkivert.",
   "drift.archive.retention": "Elementer fjernes permanent etter syv dager.",
+  "drift.archive.restoreFailed": "Kunne ikke gjenopprette elementet",
   "drift.archive.threads": "Tråder",
   "drift.archive.unknownWorkspace": "Ukjent arbeidsområde",
   "drift.attachment.download": "Last ned",

--- a/src/i18n/pl.ts
+++ b/src/i18n/pl.ts
@@ -1077,6 +1077,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Wkrótce zostanie usunięte",
   "drift.archive.empty": "Brak zarchiwizowanych elementów.",
   "drift.archive.retention": "Elementy są trwale usuwane po siedmiu dniach.",
+  "drift.archive.restoreFailed": "Nie udało się przywrócić elementu",
   "drift.archive.threads": "Wątki",
   "drift.archive.unknownWorkspace": "Nieznany obszar roboczy",
   "drift.attachment.download": "Pobierz",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1157,6 +1157,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Скоро будет удалено",
   "drift.archive.empty": "Архив пуст.",
   "drift.archive.retention": "Элементы окончательно удаляются через семь дней.",
+  "drift.archive.restoreFailed": "Не удалось восстановить элемент",
   "drift.archive.threads": "Ветки",
   "drift.archive.unknownWorkspace": "Неизвестное рабочее пространство",
   "drift.attachment.download": "Скачать",

--- a/src/i18n/th.ts
+++ b/src/i18n/th.ts
@@ -1138,6 +1138,7 @@ export const drift = {
   "drift.archive.deletesSoon": "กำลังจะลบ",
   "drift.archive.empty": "ไม่มีรายการที่เก็บถาวร",
   "drift.archive.retention": "รายการจะถูกลบถาวรหลังจากเจ็ดวัน",
+  "drift.archive.restoreFailed": "ไม่สามารถกู้คืนรายการได้",
   "drift.archive.threads": "เธรด",
   "drift.archive.unknownWorkspace": "พื้นที่ทำงานที่ไม่รู้จัก",
   "drift.attachment.download": "ดาวน์โหลด",

--- a/src/i18n/tr.ts
+++ b/src/i18n/tr.ts
@@ -1153,6 +1153,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Yakında silinir",
   "drift.archive.empty": "Arşiv boş.",
   "drift.archive.retention": "Öğeler yedi gün sonra kalıcı olarak kaldırılır.",
+  "drift.archive.restoreFailed": "Öğe geri yüklenemedi",
   "drift.archive.threads": "Konular",
   "drift.archive.unknownWorkspace": "Bilinmeyen çalışma alanı",
   "drift.attachment.download": "İndir",

--- a/src/i18n/uk.ts
+++ b/src/i18n/uk.ts
@@ -1156,6 +1156,7 @@ export const drift = {
   "drift.archive.deletesSoon": "Незабаром буде видалено",
   "drift.archive.empty": "В архіві порожньо.",
   "drift.archive.retention": "Елементи остаточно видаляються через сім днів.",
+  "drift.archive.restoreFailed": "Не вдалося відновити елемент",
   "drift.archive.threads": "Гілки",
   "drift.archive.unknownWorkspace": "Невідомий робочий простір",
   "drift.attachment.download": "Завантажити",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -1125,6 +1125,7 @@ export const drift = {
   "drift.archive.deletesSoon": "即将删除",
   "drift.archive.empty": "没有归档内容。",
   "drift.archive.retention": "项目将在七天后永久删除。",
+  "drift.archive.restoreFailed": "无法还原项目",
   "drift.archive.threads": "会话",
   "drift.archive.unknownWorkspace": "未知工作区",
   "drift.attachment.download": "下载",

--- a/src/i18n/zht.ts
+++ b/src/i18n/zht.ts
@@ -1121,6 +1121,7 @@ export const drift = {
   "drift.archive.deletesSoon": "即將刪除",
   "drift.archive.empty": "沒有封存內容。",
   "drift.archive.retention": "項目會在七天後永久刪除。",
+  "drift.archive.restoreFailed": "無法還原項目",
   "drift.archive.threads": "對話",
   "drift.archive.unknownWorkspace": "未知工作區",
   "drift.attachment.download": "下載",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,6 @@
 export type Workspace = { id: string; path: string; name: string; icon: string; lastUsed: number; removedAt?: number }
 export type ArchivedSession = { sessionId: string; workspaceId: string; archivedAt: number }
-export type PendingSessionDeletion = { sessionId: string; directory: string }
+export type PendingSessionDeletion = { sessionId: string; directory: string; claim: string }
 export type DeletionSweep = { pending: PendingSessionDeletion[]; workspaces: Workspace[] }
 export type McpConfig = Record<string, unknown> & { type: "local" | "remote" }
 export type StoredMcpServer = { name: string; config: McpConfig; updatedAt: number }
@@ -27,7 +27,8 @@ export interface DriftStore {
   removeWorkspace(id: string): Promise<void>
   prepareDeletions(before: number): Promise<DeletionSweep>
   stageWorkspaceDeletion(workspaceId: string, sessionIds: string[]): Promise<PendingSessionDeletion[]>
-  confirmDeletions(sessionIds: string[]): Promise<void>
+  claimDeletions(entries: PendingSessionDeletion[]): Promise<PendingSessionDeletion[]>
+  confirmDeletions(entries: PendingSessionDeletion[]): Promise<void>
   archived(): Promise<ArchivedSession[]>
   archiveSession(sessionId: string, workspaceId: string): Promise<void>
   unarchiveSession(sessionId: string): Promise<void>
@@ -56,7 +57,8 @@ function shellStore(invoke: Invoke): DriftStore {
     prepareDeletions: (before) => invoke("store_prepare_deletions", { before }),
     stageWorkspaceDeletion: (workspaceId, sessionIds) =>
       invoke("store_stage_workspace_deletion", { workspaceId, sessionIds }),
-    confirmDeletions: (sessionIds) => invoke("store_confirm_deletions", { sessionIds }),
+    claimDeletions: (entries) => invoke("store_claim_deletions", { entries }),
+    confirmDeletions: (entries) => invoke("store_confirm_deletions", { entries }),
     archived: () => invoke("store_archived"),
     archiveSession: (sessionId, workspaceId) => invoke("store_archive_session", { sessionId, workspaceId }),
     unarchiveSession: (sessionId) => invoke("store_unarchive_session", { sessionId }),
@@ -123,16 +125,22 @@ function browserStore(): DriftStore {
     },
     prepareDeletions: async (before) => {
       const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, [])
+      for (const entry of pending) entry.claim ||= crypto.randomUUID()
       const archives = read<ArchivedSession[]>(arKey, []).filter((entry) => entry.archivedAt < before)
       for (const archive of archives) {
         if (pending.some((entry) => entry.sessionId === archive.sessionId)) continue
         const workspace = all().find((entry) => entry.id === archive.workspaceId)
         if (workspace)
-          pending.push({ sessionId: archive.sessionId, directory: workspace.path, workspaceId: archive.workspaceId })
+          pending.push({
+            sessionId: archive.sessionId,
+            directory: workspace.path,
+            workspaceId: archive.workspaceId,
+            claim: crypto.randomUUID(),
+          })
       }
       write(pendingKey, pending)
       return {
-        pending: pending.map(({ sessionId, directory }) => ({ sessionId, directory })),
+        pending: pending.map(({ sessionId, directory, claim }) => ({ sessionId, directory, claim })),
         workspaces: all().filter((workspace) => workspace.removedAt && workspace.removedAt < before && !workspace.purgeStagedAt),
       }
     },
@@ -149,20 +157,27 @@ function browserStore(): DriftStore {
           existing.directory = workspace.path
           existing.workspaceId = workspaceId
         } else {
-          pending.push({ sessionId, directory: workspace.path, workspaceId })
+          pending.push({ sessionId, directory: workspace.path, workspaceId, claim: crypto.randomUUID() })
         }
       }
       write(pendingKey, pending)
       write(wsKey, all().map((entry) => (entry.id === workspaceId ? { ...entry, purgeStagedAt: Date.now() } : entry)))
-      return pending.map(({ sessionId, directory }) => ({ sessionId, directory }))
+      return pending.map(({ sessionId, directory, claim }) => ({ sessionId, directory, claim }))
     },
-    confirmDeletions: async (sessionIds) => {
-      const confirmed = new Set(sessionIds)
+    claimDeletions: async (entries) => {
+      const pending = read<PendingSessionDeletion[]>(pendingKey, [])
+      return entries.filter((entry) =>
+        pending.some((item) => item.sessionId === entry.sessionId && item.claim === entry.claim),
+      )
+    },
+    confirmDeletions: async (entries) => {
+      const confirmed = new Map(entries.map((entry) => [entry.sessionId, entry.claim]))
       const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, []).filter(
-        (entry) => !confirmed.has(entry.sessionId),
+        (entry) => confirmed.get(entry.sessionId) !== entry.claim,
       )
       write(pendingKey, pending)
-      write(arKey, read<ArchivedSession[]>(arKey, []).filter((entry) => !confirmed.has(entry.sessionId)))
+      const removed = new Set(entries.filter((entry) => !pending.some((item) => item.sessionId === entry.sessionId)).map((entry) => entry.sessionId))
+      write(arKey, read<ArchivedSession[]>(arKey, []).filter((entry) => !removed.has(entry.sessionId)))
       write(
         wsKey,
         all().filter(

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -30,6 +30,7 @@ export interface DriftStore {
   claimDeletions(entries: PendingSessionDeletion[]): Promise<PendingSessionDeletion[]>
   releaseDeletions(entries: PendingSessionDeletion[]): Promise<void>
   confirmDeletions(entries: PendingSessionDeletion[]): Promise<void>
+  finalizeDeletions(confirmed: PendingSessionDeletion[], retry: PendingSessionDeletion[]): Promise<void>
   archived(): Promise<ArchivedSession[]>
   archiveSession(sessionId: string, workspaceId: string): Promise<void>
   unarchiveSession(sessionId: string): Promise<void>
@@ -61,6 +62,7 @@ function shellStore(invoke: Invoke): DriftStore {
     claimDeletions: (entries) => invoke("store_claim_deletions", { entries }),
     releaseDeletions: (entries) => invoke("store_release_deletions", { entries }),
     confirmDeletions: (entries) => invoke("store_confirm_deletions", { entries }),
+    finalizeDeletions: (confirmed, retry) => invoke("store_finalize_deletions", { confirmed, retry }),
     archived: () => invoke("store_archived"),
     archiveSession: (sessionId, workspaceId) => invoke("store_archive_session", { sessionId, workspaceId }),
     unarchiveSession: (sessionId) => invoke("store_unarchive_session", { sessionId }),
@@ -104,7 +106,7 @@ function browserStore(): DriftStore {
       const existing = all().find((x) => x.path === w.path)
       if (existing) {
         if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.workspaceId === existing.id && entry.claimed))
-          throw new Error("Workspace deletion is in progress")
+          throw new Error("Deletion is in progress. Wait for it to finish, then try restoring again.")
         const restored = { ...existing, removedAt: undefined, purgeStagedAt: undefined, lastUsed: Date.now() }
         write(wsKey, [...all().filter((x) => x.id !== existing.id), restored])
         write(
@@ -216,6 +218,33 @@ function browserStore(): DriftStore {
         ),
       )
     },
+    finalizeDeletions: async (confirmed, retry) => {
+      const released = new Map(retry.map((entry) => [entry.sessionId, entry.claim]))
+      const removed = new Map(confirmed.map((entry) => [entry.sessionId, entry.claim]))
+      const pending = read<BrowserDeletion[]>(pendingKey, [])
+      for (const entry of pending) {
+        if (!entry.claimed || released.get(entry.sessionId) !== entry.claim) continue
+        entry.claim = crypto.randomUUID()
+        entry.claimed = false
+      }
+      const remaining = pending.filter((entry) => !entry.claimed || removed.get(entry.sessionId) !== entry.claim)
+      write(pendingKey, remaining)
+      const confirmedIDs = new Set(
+        confirmed
+          .filter((entry) => !remaining.some((item) => item.sessionId === entry.sessionId))
+          .map((entry) => entry.sessionId),
+      )
+      write(arKey, read<ArchivedSession[]>(arKey, []).filter((entry) => !confirmedIDs.has(entry.sessionId)))
+      write(
+        wsKey,
+        all().filter(
+          (workspace) =>
+            !workspace.removedAt ||
+            !workspace.purgeStagedAt ||
+            remaining.some((entry) => entry.workspaceId === workspace.id),
+        ),
+      )
+    },
     archived: async () => read<ArchivedSession[]>(arKey, []),
     archiveSession: async (sessionId, workspaceId) => {
       const list = read<ArchivedSession[]>(arKey, []).filter((a) => a.sessionId !== sessionId)
@@ -223,7 +252,7 @@ function browserStore(): DriftStore {
     },
     unarchiveSession: async (sessionId) => {
       if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.sessionId === sessionId && entry.claimed))
-        throw new Error("Session deletion is in progress")
+        throw new Error("Deletion is in progress. Wait for it to finish, then try restoring again.")
       write(arKey, read<ArchivedSession[]>(arKey, []).filter((a) => a.sessionId !== sessionId))
       write(
         pendingKey,

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,5 +1,7 @@
 export type Workspace = { id: string; path: string; name: string; icon: string; lastUsed: number; removedAt?: number }
 export type ArchivedSession = { sessionId: string; workspaceId: string; archivedAt: number }
+export type PendingSessionDeletion = { sessionId: string; directory: string }
+export type DeletionSweep = { pending: PendingSessionDeletion[]; workspaces: Workspace[] }
 export type McpConfig = Record<string, unknown> & { type: "local" | "remote" }
 export type StoredMcpServer = { name: string; config: McpConfig; updatedAt: number }
 export type McpDecision = "pending" | "approved" | "rejected" | "invalid"
@@ -23,11 +25,12 @@ export interface DriftStore {
   saveWorkspace(workspace: Omit<Workspace, "lastUsed">): Promise<void>
   touchWorkspace(id: string): Promise<void>
   removeWorkspace(id: string): Promise<void>
-  purgeRemovedWorkspaces(before: number): Promise<string[]>
+  prepareDeletions(before: number): Promise<DeletionSweep>
+  stageWorkspaceDeletion(workspaceId: string, sessionIds: string[]): Promise<PendingSessionDeletion[]>
+  confirmDeletions(sessionIds: string[]): Promise<void>
   archived(): Promise<ArchivedSession[]>
   archiveSession(sessionId: string, workspaceId: string): Promise<void>
   unarchiveSession(sessionId: string): Promise<void>
-  purgeArchived(before: number): Promise<string[]>
   mcpSnapshot(directory: string): Promise<McpSnapshot>
   saveMcp(name: string, config: McpConfig, generation: number, previousName?: string): Promise<void>
   removeMcp(name: string, generation: number): Promise<void>
@@ -50,11 +53,13 @@ function shellStore(invoke: Invoke): DriftStore {
     saveWorkspace: (w) => invoke("store_save_workspace", { id: w.id, path: w.path, name: w.name, icon: w.icon }),
     touchWorkspace: (id) => invoke("store_touch_workspace", { id }),
     removeWorkspace: (id) => invoke("store_remove_workspace", { id }),
-    purgeRemovedWorkspaces: (before) => invoke("store_purge_removed_workspaces", { before }),
+    prepareDeletions: (before) => invoke("store_prepare_deletions", { before }),
+    stageWorkspaceDeletion: (workspaceId, sessionIds) =>
+      invoke("store_stage_workspace_deletion", { workspaceId, sessionIds }),
+    confirmDeletions: (sessionIds) => invoke("store_confirm_deletions", { sessionIds }),
     archived: () => invoke("store_archived"),
     archiveSession: (sessionId, workspaceId) => invoke("store_archive_session", { sessionId, workspaceId }),
     unarchiveSession: (sessionId) => invoke("store_unarchive_session", { sessionId }),
-    purgeArchived: (before) => invoke("store_purge_archived", { before }),
     mcpSnapshot: (directory) => invoke("mcp_snapshot", { directory }),
     saveMcp: (name, config, generation, previousName) =>
       invoke("mcp_save", { name, config, generation, previousName }),
@@ -77,11 +82,12 @@ function write(key: string, value: unknown) {
   localStorage.setItem(key, JSON.stringify(value))
 }
 
-type StoredWorkspace = Workspace & { removedAt?: number }
+type StoredWorkspace = Workspace & { removedAt?: number; purgeStagedAt?: number }
 
 function browserStore(): DriftStore {
   const wsKey = "drift.store.workspaces"
   const arKey = "drift.store.archived"
+  const pendingKey = "drift.store.pending-session-delete"
   const all = () => read<StoredWorkspace[]>(wsKey, [])
   const desktopMcpOnly = async (): Promise<never> => {
     throw new Error("MCP policy requires the Drift desktop backend")
@@ -92,8 +98,14 @@ function browserStore(): DriftStore {
     addWorkspace: async (w) => {
       const existing = all().find((x) => x.path === w.path)
       if (existing) {
-        const restored = { ...existing, removedAt: undefined, lastUsed: Date.now() }
+        const restored = { ...existing, removedAt: undefined, purgeStagedAt: undefined, lastUsed: Date.now() }
         write(wsKey, [...all().filter((x) => x.id !== existing.id), restored])
+        write(
+          pendingKey,
+          read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, []).filter(
+            (entry) => entry.workspaceId !== existing.id,
+          ),
+        )
         return restored
       }
       const created = { ...w, lastUsed: Date.now() }
@@ -109,11 +121,57 @@ function browserStore(): DriftStore {
     removeWorkspace: async (id) => {
       write(wsKey, all().map((w) => (w.id === id ? { ...w, removedAt: Date.now() } : w)))
     },
-    purgeRemovedWorkspaces: async (before) => {
-      const gone = all().filter((w) => w.removedAt && w.removedAt < before)
-      write(wsKey, all().filter((w) => !gone.some((g) => g.id === w.id)))
-      write(arKey, read<ArchivedSession[]>(arKey, []).filter((a) => !gone.some((g) => g.id === a.workspaceId)))
-      return gone.map((w) => w.path)
+    prepareDeletions: async (before) => {
+      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, [])
+      const archives = read<ArchivedSession[]>(arKey, []).filter((entry) => entry.archivedAt < before)
+      for (const archive of archives) {
+        if (pending.some((entry) => entry.sessionId === archive.sessionId)) continue
+        const workspace = all().find((entry) => entry.id === archive.workspaceId)
+        if (workspace)
+          pending.push({ sessionId: archive.sessionId, directory: workspace.path, workspaceId: archive.workspaceId })
+      }
+      write(pendingKey, pending)
+      return {
+        pending: pending.map(({ sessionId, directory }) => ({ sessionId, directory })),
+        workspaces: all().filter((workspace) => workspace.removedAt && workspace.removedAt < before && !workspace.purgeStagedAt),
+      }
+    },
+    stageWorkspaceDeletion: async (workspaceId, sessionIds) => {
+      const workspace = all().find((entry) => entry.id === workspaceId && entry.removedAt)
+      if (!workspace) return read<PendingSessionDeletion[]>(pendingKey, [])
+      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, [])
+      const archived = read<ArchivedSession[]>(arKey, [])
+        .filter((entry) => entry.workspaceId === workspaceId)
+        .map((entry) => entry.sessionId)
+      for (const sessionId of [...sessionIds, ...archived]) {
+        const existing = pending.find((entry) => entry.sessionId === sessionId)
+        if (existing) {
+          existing.directory = workspace.path
+          existing.workspaceId = workspaceId
+        } else {
+          pending.push({ sessionId, directory: workspace.path, workspaceId })
+        }
+      }
+      write(pendingKey, pending)
+      write(wsKey, all().map((entry) => (entry.id === workspaceId ? { ...entry, purgeStagedAt: Date.now() } : entry)))
+      return pending.map(({ sessionId, directory }) => ({ sessionId, directory }))
+    },
+    confirmDeletions: async (sessionIds) => {
+      const confirmed = new Set(sessionIds)
+      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, []).filter(
+        (entry) => !confirmed.has(entry.sessionId),
+      )
+      write(pendingKey, pending)
+      write(arKey, read<ArchivedSession[]>(arKey, []).filter((entry) => !confirmed.has(entry.sessionId)))
+      write(
+        wsKey,
+        all().filter(
+          (workspace) =>
+            !workspace.removedAt ||
+            !workspace.purgeStagedAt ||
+            pending.some((entry) => entry.workspaceId === workspace.id),
+        ),
+      )
     },
     archived: async () => read<ArchivedSession[]>(arKey, []),
     archiveSession: async (sessionId, workspaceId) => {
@@ -122,11 +180,10 @@ function browserStore(): DriftStore {
     },
     unarchiveSession: async (sessionId) => {
       write(arKey, read<ArchivedSession[]>(arKey, []).filter((a) => a.sessionId !== sessionId))
-    },
-    purgeArchived: async (before) => {
-      const list = read<ArchivedSession[]>(arKey, [])
-      write(arKey, list.filter((a) => a.archivedAt >= before))
-      return list.filter((a) => a.archivedAt < before).map((a) => a.sessionId)
+      write(
+        pendingKey,
+        read<PendingSessionDeletion[]>(pendingKey, []).filter((entry) => entry.sessionId !== sessionId),
+      )
     },
     mcpSnapshot: desktopMcpOnly,
     saveMcp: desktopMcpOnly,

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,6 +2,11 @@ export type Workspace = { id: string; path: string; name: string; icon: string; 
 export type ArchivedSession = { sessionId: string; workspaceId: string; archivedAt: number }
 export type PendingSessionDeletion = { sessionId: string; directory: string; claim: string }
 export type DeletionSweep = { pending: PendingSessionDeletion[]; workspaces: Workspace[] }
+/**
+ * A claim held longer than this is treated as abandoned: the sweep holding it died or was pinned by a
+ * hung engine request. Must stay above the engine sweep budget so a live sweep keeps its own claims.
+ */
+export const claimDeadline = 5 * 60 * 1000
 export type McpConfig = Record<string, unknown> & { type: "local" | "remote" }
 export type StoredMcpServer = { name: string; config: McpConfig; updatedAt: number }
 export type McpDecision = "pending" | "approved" | "rejected" | "invalid"
@@ -89,7 +94,9 @@ function write(key: string, value: unknown) {
 }
 
 type StoredWorkspace = Workspace & { removedAt?: number; purgeStagedAt?: number }
-type BrowserDeletion = PendingSessionDeletion & { workspaceId?: string; claimed?: boolean }
+type BrowserDeletion = PendingSessionDeletion & { workspaceId?: string; claimed?: boolean; claimedAt?: number }
+
+const claimActive = (entry: BrowserDeletion) => !!entry.claimed && Date.now() - (entry.claimedAt ?? 0) < claimDeadline
 
 function browserStore(): DriftStore {
   const wsKey = "drift.store.workspaces"
@@ -105,7 +112,7 @@ function browserStore(): DriftStore {
     addWorkspace: async (w) => {
       const existing = all().find((x) => x.path === w.path)
       if (existing) {
-        if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.workspaceId === existing.id && entry.claimed))
+        if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.workspaceId === existing.id && claimActive(entry)))
           throw new Error("Deletion is in progress. Wait for it to finish, then try restoring again.")
         const restored = { ...existing, removedAt: undefined, purgeStagedAt: undefined, lastUsed: Date.now() }
         write(wsKey, [...all().filter((x) => x.id !== existing.id), restored])
@@ -133,8 +140,11 @@ function browserStore(): DriftStore {
     prepareDeletions: async (before) => {
       const pending = read<BrowserDeletion[]>(pendingKey, [])
       for (const entry of pending) {
+        // Leave live claims alone; reclaim abandoned ones so a hung sweep cannot pin them forever.
+        if (claimActive(entry)) continue
         if (entry.claimed) entry.claim = crypto.randomUUID()
         entry.claimed = false
+        entry.claimedAt = undefined
         entry.claim ||= crypto.randomUUID()
       }
       const archives = read<ArchivedSession[]>(arKey, []).filter((entry) => entry.archivedAt < before)
@@ -180,11 +190,12 @@ function browserStore(): DriftStore {
       const claimed: PendingSessionDeletion[] = []
       for (const entry of entries) {
         const current = pending.find(
-          (item) => item.sessionId === entry.sessionId && item.claim === entry.claim && !item.claimed,
+          (item) => item.sessionId === entry.sessionId && item.claim === entry.claim && !claimActive(item),
         )
         if (!current) continue
         current.claim = crypto.randomUUID()
         current.claimed = true
+        current.claimedAt = Date.now()
         claimed.push({ sessionId: current.sessionId, directory: current.directory, claim: current.claim })
       }
       write(pendingKey, pending)
@@ -197,6 +208,7 @@ function browserStore(): DriftStore {
         if (!entry.claimed || claims.get(entry.sessionId) !== entry.claim) continue
         entry.claim = crypto.randomUUID()
         entry.claimed = false
+        entry.claimedAt = undefined
       }
       write(pendingKey, pending)
     },
@@ -226,6 +238,7 @@ function browserStore(): DriftStore {
         if (!entry.claimed || released.get(entry.sessionId) !== entry.claim) continue
         entry.claim = crypto.randomUUID()
         entry.claimed = false
+        entry.claimedAt = undefined
       }
       const remaining = pending.filter((entry) => !entry.claimed || removed.get(entry.sessionId) !== entry.claim)
       write(pendingKey, remaining)
@@ -251,7 +264,7 @@ function browserStore(): DriftStore {
       write(arKey, [...list, { sessionId, workspaceId, archivedAt: Date.now() }])
     },
     unarchiveSession: async (sessionId) => {
-      if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.sessionId === sessionId && entry.claimed))
+      if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.sessionId === sessionId && claimActive(entry)))
         throw new Error("Deletion is in progress. Wait for it to finish, then try restoring again.")
       write(arKey, read<ArchivedSession[]>(arKey, []).filter((a) => a.sessionId !== sessionId))
       write(

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -28,6 +28,7 @@ export interface DriftStore {
   prepareDeletions(before: number): Promise<DeletionSweep>
   stageWorkspaceDeletion(workspaceId: string, sessionIds: string[]): Promise<PendingSessionDeletion[]>
   claimDeletions(entries: PendingSessionDeletion[]): Promise<PendingSessionDeletion[]>
+  releaseDeletions(entries: PendingSessionDeletion[]): Promise<void>
   confirmDeletions(entries: PendingSessionDeletion[]): Promise<void>
   archived(): Promise<ArchivedSession[]>
   archiveSession(sessionId: string, workspaceId: string): Promise<void>
@@ -58,6 +59,7 @@ function shellStore(invoke: Invoke): DriftStore {
     stageWorkspaceDeletion: (workspaceId, sessionIds) =>
       invoke("store_stage_workspace_deletion", { workspaceId, sessionIds }),
     claimDeletions: (entries) => invoke("store_claim_deletions", { entries }),
+    releaseDeletions: (entries) => invoke("store_release_deletions", { entries }),
     confirmDeletions: (entries) => invoke("store_confirm_deletions", { entries }),
     archived: () => invoke("store_archived"),
     archiveSession: (sessionId, workspaceId) => invoke("store_archive_session", { sessionId, workspaceId }),
@@ -85,6 +87,7 @@ function write(key: string, value: unknown) {
 }
 
 type StoredWorkspace = Workspace & { removedAt?: number; purgeStagedAt?: number }
+type BrowserDeletion = PendingSessionDeletion & { workspaceId?: string; claimed?: boolean }
 
 function browserStore(): DriftStore {
   const wsKey = "drift.store.workspaces"
@@ -100,11 +103,13 @@ function browserStore(): DriftStore {
     addWorkspace: async (w) => {
       const existing = all().find((x) => x.path === w.path)
       if (existing) {
+        if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.workspaceId === existing.id && entry.claimed))
+          throw new Error("Workspace deletion is in progress")
         const restored = { ...existing, removedAt: undefined, purgeStagedAt: undefined, lastUsed: Date.now() }
         write(wsKey, [...all().filter((x) => x.id !== existing.id), restored])
         write(
           pendingKey,
-          read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, []).filter(
+          read<BrowserDeletion[]>(pendingKey, []).filter(
             (entry) => entry.workspaceId !== existing.id,
           ),
         )
@@ -124,8 +129,12 @@ function browserStore(): DriftStore {
       write(wsKey, all().map((w) => (w.id === id ? { ...w, removedAt: Date.now() } : w)))
     },
     prepareDeletions: async (before) => {
-      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, [])
-      for (const entry of pending) entry.claim ||= crypto.randomUUID()
+      const pending = read<BrowserDeletion[]>(pendingKey, [])
+      for (const entry of pending) {
+        if (entry.claimed) entry.claim = crypto.randomUUID()
+        entry.claimed = false
+        entry.claim ||= crypto.randomUUID()
+      }
       const archives = read<ArchivedSession[]>(arKey, []).filter((entry) => entry.archivedAt < before)
       for (const archive of archives) {
         if (pending.some((entry) => entry.sessionId === archive.sessionId)) continue
@@ -147,7 +156,7 @@ function browserStore(): DriftStore {
     stageWorkspaceDeletion: async (workspaceId, sessionIds) => {
       const workspace = all().find((entry) => entry.id === workspaceId && entry.removedAt)
       if (!workspace) return read<PendingSessionDeletion[]>(pendingKey, [])
-      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, [])
+      const pending = read<BrowserDeletion[]>(pendingKey, [])
       const archived = read<ArchivedSession[]>(arKey, [])
         .filter((entry) => entry.workspaceId === workspaceId)
         .map((entry) => entry.sessionId)
@@ -165,15 +174,34 @@ function browserStore(): DriftStore {
       return pending.map(({ sessionId, directory, claim }) => ({ sessionId, directory, claim }))
     },
     claimDeletions: async (entries) => {
-      const pending = read<PendingSessionDeletion[]>(pendingKey, [])
-      return entries.filter((entry) =>
-        pending.some((item) => item.sessionId === entry.sessionId && item.claim === entry.claim),
-      )
+      const pending = read<BrowserDeletion[]>(pendingKey, [])
+      const claimed: PendingSessionDeletion[] = []
+      for (const entry of entries) {
+        const current = pending.find(
+          (item) => item.sessionId === entry.sessionId && item.claim === entry.claim && !item.claimed,
+        )
+        if (!current) continue
+        current.claim = crypto.randomUUID()
+        current.claimed = true
+        claimed.push({ sessionId: current.sessionId, directory: current.directory, claim: current.claim })
+      }
+      write(pendingKey, pending)
+      return claimed
+    },
+    releaseDeletions: async (entries) => {
+      const claims = new Map(entries.map((entry) => [entry.sessionId, entry.claim]))
+      const pending = read<BrowserDeletion[]>(pendingKey, [])
+      for (const entry of pending) {
+        if (!entry.claimed || claims.get(entry.sessionId) !== entry.claim) continue
+        entry.claim = crypto.randomUUID()
+        entry.claimed = false
+      }
+      write(pendingKey, pending)
     },
     confirmDeletions: async (entries) => {
       const confirmed = new Map(entries.map((entry) => [entry.sessionId, entry.claim]))
-      const pending = read<(PendingSessionDeletion & { workspaceId?: string })[]>(pendingKey, []).filter(
-        (entry) => confirmed.get(entry.sessionId) !== entry.claim,
+      const pending = read<BrowserDeletion[]>(pendingKey, []).filter(
+        (entry) => !entry.claimed || confirmed.get(entry.sessionId) !== entry.claim,
       )
       write(pendingKey, pending)
       const removed = new Set(entries.filter((entry) => !pending.some((item) => item.sessionId === entry.sessionId)).map((entry) => entry.sessionId))
@@ -194,10 +222,12 @@ function browserStore(): DriftStore {
       write(arKey, [...list, { sessionId, workspaceId, archivedAt: Date.now() }])
     },
     unarchiveSession: async (sessionId) => {
+      if (read<BrowserDeletion[]>(pendingKey, []).some((entry) => entry.sessionId === sessionId && entry.claimed))
+        throw new Error("Session deletion is in progress")
       write(arKey, read<ArchivedSession[]>(arKey, []).filter((a) => a.sessionId !== sessionId))
       write(
         pendingKey,
-        read<PendingSessionDeletion[]>(pendingKey, []).filter((entry) => entry.sessionId !== sessionId),
+        read<BrowserDeletion[]>(pendingKey, []).filter((entry) => entry.sessionId !== sessionId),
       )
     },
     mcpSnapshot: desktopMcpOnly,

--- a/src/state/workspaces.ts
+++ b/src/state/workspaces.ts
@@ -140,6 +140,10 @@ export function claimDeletions(entries: PendingSessionDeletion[]) {
   return driftStore.claimDeletions(entries)
 }
 
+export function releaseDeletions(entries: PendingSessionDeletion[]) {
+  return driftStore.releaseDeletions(entries)
+}
+
 export async function confirmDeletions(entries: PendingSessionDeletion[]) {
   await driftStore.confirmDeletions(entries)
   await refreshArchives()

--- a/src/state/workspaces.ts
+++ b/src/state/workspaces.ts
@@ -136,8 +136,12 @@ export function stageWorkspaceDeletion(workspaceId: string, sessionIds: string[]
   return driftStore.stageWorkspaceDeletion(workspaceId, sessionIds)
 }
 
+export function claimDeletions(entries: PendingSessionDeletion[]) {
+  return driftStore.claimDeletions(entries)
+}
+
 export async function confirmDeletions(entries: PendingSessionDeletion[]) {
-  await driftStore.confirmDeletions(entries.map((entry) => entry.sessionId))
+  await driftStore.confirmDeletions(entries)
   await refreshArchives()
   await refreshWorkspaces()
 }

--- a/src/state/workspaces.ts
+++ b/src/state/workspaces.ts
@@ -71,6 +71,10 @@ async function refreshArchives() {
   setArchivedIds(new Set(sessions.map((entry) => entry.sessionId)))
 }
 
+export function refreshArchiveState() {
+  return Promise.all([refreshWorkspaces(), refreshArchives()])
+}
+
 export function selectWorkspace(id: string) {
   if (activeWorkspaceId() !== id) selectSession(null)
   setActiveWorkspaceId(id)
@@ -148,4 +152,12 @@ export async function confirmDeletions(entries: PendingSessionDeletion[]) {
   await driftStore.confirmDeletions(entries)
   await refreshArchives()
   await refreshWorkspaces()
+}
+
+export async function finalizeDeletions(
+  confirmed: PendingSessionDeletion[],
+  retry: PendingSessionDeletion[],
+) {
+  await driftStore.finalizeDeletions(confirmed, retry)
+  await refreshArchiveState()
 }

--- a/src/state/workspaces.ts
+++ b/src/state/workspaces.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js"
 import { selectSession } from "./selection"
 import { persisted } from "./persist"
-import { driftStore, type ArchivedSession, type Workspace } from "./store"
+import { driftStore, type ArchivedSession, type PendingSessionDeletion, type Workspace } from "./store"
 
 const [rawWorkspaces, setWorkspaces] = createSignal<Workspace[]>([])
 const [workspacesReady, setWorkspacesReady] = createSignal(false)
@@ -126,16 +126,18 @@ export async function unarchiveSession(sessionId: string) {
   await refreshArchives()
 }
 
-const purgeAge = 7 * 24 * 60 * 60 * 1000
+export const purgeAge = 7 * 24 * 60 * 60 * 1000
 
-export async function purgeArchived() {
-  const ids = await driftStore.purgeArchived(Date.now() - purgeAge)
-  await refreshArchives()
-  return ids
+export function prepareDeletions(before: number) {
+  return driftStore.prepareDeletions(before)
 }
 
-export async function purgeRemovedWorkspaces() {
-  const paths = await driftStore.purgeRemovedWorkspaces(Date.now() - purgeAge)
+export function stageWorkspaceDeletion(workspaceId: string, sessionIds: string[]) {
+  return driftStore.stageWorkspaceDeletion(workspaceId, sessionIds)
+}
+
+export async function confirmDeletions(entries: PendingSessionDeletion[]) {
+  await driftStore.confirmDeletions(entries.map((entry) => entry.sessionId))
+  await refreshArchives()
   await refreshWorkspaces()
-  return paths
 }

--- a/src/ui/archive.tsx
+++ b/src/ui/archive.tsx
@@ -5,6 +5,7 @@ import { t } from "../state/i18n"
 import { selectSession } from "../state/selection"
 import {
   archivedSessions,
+  refreshArchiveState,
   removedWorkspaces,
   restoreWorkspace,
   selectWorkspace,
@@ -34,6 +35,19 @@ export function ArchiveModal(props: { onClose: () => void }) {
     await unarchiveSession(sessionId)
     selectSession(sessionId)
     props.onClose()
+  }
+
+  async function restore(action: () => Promise<void>) {
+    try {
+      await action()
+    } catch (error) {
+      await refreshArchiveState().catch(() => undefined)
+      engine.actions.notice({
+        title: t("drift.archive.restoreFailed"),
+        message: error instanceof Error ? error.message : String(error),
+        variant: "error",
+      })
+    }
   }
 
   return (
@@ -74,7 +88,10 @@ export function ArchiveModal(props: { onClose: () => void }) {
                       title={workspace.name}
                       detail={`${workspace.path} · ${expiry(workspace.removedAt)}`}
                       icon={<WorkspaceIcon workspace={workspace} />}
-                      onRestore={() => void restoreWorkspace(workspace).then(props.onClose)}
+                      onRestore={() => void restore(async () => {
+                        await restoreWorkspace(workspace)
+                        props.onClose()
+                      })}
                     />
                   )}
                 </For>
@@ -90,7 +107,7 @@ export function ArchiveModal(props: { onClose: () => void }) {
                       <ArchiveRow
                         title={session()?.title || t("drift.thread.untitled")}
                         detail={`${workspace()?.name ?? t("drift.archive.unknownWorkspace")} · ${expiry(entry.archivedAt)}`}
-                        onRestore={() => void restoreThread(entry.sessionId, entry.workspaceId)}
+                        onRestore={() => void restore(() => restoreThread(entry.sessionId, entry.workspaceId))}
                       />
                     )
                   }}

--- a/tests/deletion.test.ts
+++ b/tests/deletion.test.ts
@@ -10,9 +10,9 @@ if (!("localStorage" in globalThis))
 test("pending deletion confirms successes and retries only failed exact IDs", async () => {
   const [state, set] = createEngineState()
   const entries: PendingSessionDeletion[] = [
-    { sessionId: "old-success", directory: "C:/reused" },
-    { sessionId: "old-retry", directory: "C:/reused" },
-    { sessionId: "old-missing", directory: "C:/reused" },
+    { sessionId: "old-success", directory: "C:/reused", claim: "claim-success" },
+    { sessionId: "old-retry", directory: "C:/reused", claim: "claim-retry" },
+    { sessionId: "old-missing", directory: "C:/reused", claim: "claim-missing" },
   ]
   const attempts: string[] = []
   const originalFetch = globalThis.fetch
@@ -20,9 +20,10 @@ test("pending deletion confirms successes and retries only failed exact IDs", as
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init)
     const id = new URL(request.url).pathname.split("/").at(-1) ?? ""
-    attempts.push(id)
+    attempts.push(`${request.method}:${id}`)
     if (id === "old-retry" && retryFails) return Response.json({ message: "offline" }, { status: 503 })
     if (id === "old-missing") return new Response(null, { status: 404 })
+    if (request.method === "GET") return new Response(null, { status: 404 })
     return Response.json(true)
   }) as typeof fetch
 
@@ -36,8 +37,64 @@ test("pending deletion confirms successes and retries only failed exact IDs", as
     expect(await actions.removePendingSessions(entries)).toEqual([entries[0], entries[2]])
     retryFails = false
     expect(await actions.removePendingSessions([entries[1]])).toEqual([entries[1]])
-    expect(attempts).toEqual(["old-success", "old-retry", "old-missing", "old-retry"])
-    expect(attempts).not.toContain("new-session-at-reused-path")
+    expect(attempts).toEqual([
+      "DELETE:old-success",
+      "GET:old-success",
+      "DELETE:old-retry",
+      "DELETE:old-missing",
+      "DELETE:old-retry",
+      "GET:old-retry",
+    ])
+    expect(attempts).not.toContain("DELETE:new-session-at-reused-path")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("pending deletion keeps its claim when a successful delete did not remove the exact session", async () => {
+  const [state, set] = createEngineState()
+  const entry = { sessionId: "still-present", directory: "C:/reused", claim: "opaque" }
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    return request.method === "DELETE" ? Response.json(true) : Response.json({ id: entry.sessionId })
+  }) as typeof fetch
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.removePendingSessions([entry])).toEqual([])
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("workspace purge session discovery follows every experimental session cursor", async () => {
+  const [state, set] = createEngineState()
+  const cursors: (string | null)[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input))
+    const cursor = url.searchParams.get("cursor")
+    cursors.push(cursor)
+    if (!cursor)
+      return Response.json([{ id: "newer" }], { headers: { "x-next-cursor": "200" } })
+    if (cursor === "200")
+      return Response.json([{ id: "older" }], { headers: { "x-next-cursor": "100" } })
+    return Response.json([{ id: "oldest" }])
+  }) as typeof fetch
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.sessionIdsAt("C:/purge")).toEqual(["newer", "older", "oldest"])
+    expect(cursors).toEqual([null, "200", "100"])
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/tests/deletion.test.ts
+++ b/tests/deletion.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { createActions, type PendingSessionDeletion } from "../src/engine/actions"
+import { createEngineState } from "../src/engine/store"
+
+if (!("localStorage" in globalThis))
+  Object.defineProperty(globalThis, "localStorage", {
+    value: { getItem: () => null, setItem: () => undefined },
+  })
+
+test("pending deletion confirms successes and retries only failed exact IDs", async () => {
+  const [state, set] = createEngineState()
+  const entries: PendingSessionDeletion[] = [
+    { sessionId: "old-success", directory: "C:/reused" },
+    { sessionId: "old-retry", directory: "C:/reused" },
+    { sessionId: "old-missing", directory: "C:/reused" },
+  ]
+  const attempts: string[] = []
+  const originalFetch = globalThis.fetch
+  let retryFails = true
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const id = new URL(request.url).pathname.split("/").at(-1) ?? ""
+    attempts.push(id)
+    if (id === "old-retry" && retryFails) return Response.json({ message: "offline" }, { status: 503 })
+    if (id === "old-missing") return new Response(null, { status: 404 })
+    return Response.json(true)
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.removePendingSessions(entries)).toEqual([entries[0], entries[2]])
+    retryFails = false
+    expect(await actions.removePendingSessions([entries[1]])).toEqual([entries[1]])
+    expect(attempts).toEqual(["old-success", "old-retry", "old-missing", "old-retry"])
+    expect(attempts).not.toContain("new-session-at-reused-path")
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/tests/deletion.test.ts
+++ b/tests/deletion.test.ts
@@ -34,9 +34,12 @@ test("pending deletion confirms successes and retries only failed exact IDs", as
       set,
       () => ({ url: "http://engine.test" }),
     )
-    expect(await actions.removePendingSessions(entries)).toEqual([entries[0], entries[2]])
+    expect(await actions.removePendingSessions(entries)).toEqual({
+      confirmed: [entries[0], entries[2]],
+      retry: [entries[1]],
+    })
     retryFails = false
-    expect(await actions.removePendingSessions([entries[1]])).toEqual([entries[1]])
+    expect(await actions.removePendingSessions([entries[1]])).toEqual({ confirmed: [entries[1]], retry: [] })
     expect(attempts).toEqual([
       "DELETE:old-success",
       "GET:old-success",
@@ -66,7 +69,78 @@ test("pending deletion keeps its claim when a successful delete did not remove t
       set,
       () => ({ url: "http://engine.test" }),
     )
-    expect(await actions.removePendingSessions([entry])).toEqual([])
+    expect(await actions.removePendingSessions([entry])).toEqual({ confirmed: [], retry: [] })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a hung deletion request resolves the sweep without releasing the claim, then confirms on a later sweep", async () => {
+  const [state, set] = createEngineState()
+  const entry = { sessionId: "hung", directory: "C:/reused", claim: "opaque" }
+  const originalFetch = globalThis.fetch
+  let hang = true
+  const aborted: string[] = []
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    if (!hang) return Promise.resolve(new Response(null, { status: 404 }))
+    // Never settles on its own; only the caller's deadline can abort it.
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        aborted.push(request.method)
+        reject(new DOMException("Aborted", "AbortError"))
+      })
+    })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    const hungSweep = actions.removePendingSessions([entry], { request: 25, sweep: 5000 })
+    // The sweep must settle on its own deadline rather than hanging until the app restarts.
+    expect(await hungSweep).toEqual({ confirmed: [], retry: [] })
+    expect(aborted).toEqual(["DELETE"])
+
+    hang = false
+    expect(await actions.removePendingSessions([entry])).toEqual({ confirmed: [entry], retry: [] })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("an exhausted sweep budget releases entries it never sent to the engine", async () => {
+  const [state, set] = createEngineState()
+  const entries: PendingSessionDeletion[] = [
+    { sessionId: "attempted", directory: "C:/reused", claim: "claim-attempted" },
+    { sessionId: "untouched", directory: "C:/reused", claim: "claim-untouched" },
+  ]
+  const attempted: string[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    attempted.push(new URL(request.url).pathname.split("/").at(-1) ?? "")
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")))
+    })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    // The first entry burns the whole budget, so the second is never sent and is safe to unclaim.
+    expect(await actions.removePendingSessions(entries, { request: 30, sweep: 20 })).toEqual({
+      confirmed: [],
+      retry: [entries[1]],
+    })
+    expect(attempted).toEqual(["attempted"])
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/tests/deletion.test.ts
+++ b/tests/deletion.test.ts
@@ -74,16 +74,21 @@ test("pending deletion keeps its claim when a successful delete did not remove t
 
 test("workspace purge session discovery follows every experimental session cursor", async () => {
   const [state, set] = createEngineState()
-  const cursors: (string | null)[] = []
+  const cursors: [string | null, string | null][] = []
   const originalFetch = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = new URL(String(input))
     const cursor = url.searchParams.get("cursor")
-    cursors.push(cursor)
+    const cursorID = url.searchParams.get("cursorID")
+    cursors.push([cursor, cursorID])
     if (!cursor)
-      return Response.json([{ id: "newer" }], { headers: { "x-next-cursor": "200" } })
+      return Response.json([{ id: "newer" }], {
+        headers: { "x-next-cursor": "200", "x-next-cursor-id": "newer" },
+      })
     if (cursor === "200")
-      return Response.json([{ id: "older" }], { headers: { "x-next-cursor": "100" } })
+      return Response.json([{ id: "older" }], {
+        headers: { "x-next-cursor": "100", "x-next-cursor-id": "older" },
+      })
     return Response.json([{ id: "oldest" }])
   }) as typeof fetch
   try {
@@ -94,7 +99,11 @@ test("workspace purge session discovery follows every experimental session curso
       () => ({ url: "http://engine.test" }),
     )
     expect(await actions.sessionIdsAt("C:/purge")).toEqual(["newer", "older", "oldest"])
-    expect(cursors).toEqual([null, "200", "100"])
+    expect(cursors).toEqual([
+      [null, null],
+      ["200", "newer"],
+      ["100", "older"],
+    ])
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/tests/move.test.ts
+++ b/tests/move.test.ts
@@ -38,7 +38,7 @@ test("metadata-only session moves retain history and move the descendant tree", 
   const sessions = [session("root", source), session("child", source, "root"), session("sibling", source)]
   const [state, set] = createEngineState()
   for (const entry of sessions) set("sessions", entry.id, entry)
-  const requests: { id: string; moveChanges: boolean }[] = []
+  const requests: { id: string; moveChanges: boolean; source: string }[] = []
   const originalFetch = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init)
@@ -48,12 +48,17 @@ test("metadata-only session moves retain history and move the descendant tree", 
       const data = directory === source ? sessions : sessions.map((entry) => ({ ...entry, directory: destination, projectID: "new-project" }))
       return Response.json(data)
     }
+    if (request.method === "GET" && url.pathname === "/session/status") return Response.json({})
     const body = (await request.json()) as {
       sessionID: string
       destination: { directory: string }
       moveChanges: boolean
     }
-    requests.push({ id: body.sessionID, moveChanges: body.moveChanges })
+    requests.push({
+      id: body.sessionID,
+      moveChanges: body.moveChanges,
+      source: decodeURIComponent(request.headers.get("x-opencode-directory") ?? ""),
+    })
     return new Response(null, { status: 204 })
   }) as typeof fetch
 
@@ -66,13 +71,86 @@ test("metadata-only session moves retain history and move the descendant tree", 
     )
     expect(await actions.moveSession("root", destination)).toEqual({ ok: true, moved: ["root", "child"] })
     expect(requests).toEqual([
-      { id: "root", moveChanges: false },
-      { id: "child", moveChanges: false },
+      { id: "root", moveChanges: false, source },
+      { id: "child", moveChanges: false, source },
     ])
     expect(state.sessions.root.directory).toBe(destination)
     expect(state.sessions.root.projectID).toBe("new-project")
     expect(state.sessions.child.directory).toBe(destination)
     expect(state.sessions.sibling.directory).toBe(source)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("session moves reject a tree that is still active before rebinding", async () => {
+  const source = "C:/one"
+  const destination = "C:/two"
+  const sessions = [session("root", source), session("child", source, "root")]
+  const [state, set] = createEngineState()
+  for (const entry of sessions) set("sessions", entry.id, entry)
+  const originalFetch = globalThis.fetch
+  let moves = 0
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url)
+    if (url.pathname === "/experimental/session") return Response.json(sessions)
+    if (url.pathname === "/session/status") return Response.json({ child: { type: "busy" } })
+    moves += 1
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.moveSession("root", destination)).toEqual({
+      ok: false,
+      moved: [],
+      error: "Session child is still active",
+    })
+    expect(moves).toBe(0)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("a partially failed tree move rolls completed sessions back to their source", async () => {
+  const source = "C:/one"
+  const destination = "C:/two"
+  const sessions = [session("root", source), session("child", source, "root")]
+  const [state, set] = createEngineState()
+  for (const entry of sessions) set("sessions", entry.id, entry)
+  const requests: { id: string; destination: string }[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url)
+    if (url.pathname === "/experimental/session") return Response.json(sessions)
+    if (url.pathname === "/session/status") return Response.json({})
+    const body = (await request.json()) as { sessionID: string; destination: { directory: string } }
+    requests.push({ id: body.sessionID, destination: body.destination.directory })
+    if (body.sessionID === "child")
+      return Response.json({ data: { message: "still active" } }, { status: 400 })
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.moveSession("root", destination)).toEqual({ ok: false, moved: [], error: "still active" })
+    expect(requests).toEqual([
+      { id: "root", destination },
+      { id: "child", destination },
+      { id: "root", destination: source },
+    ])
   } finally {
     globalThis.fetch = originalFetch
   }

--- a/tests/move.test.ts
+++ b/tests/move.test.ts
@@ -156,6 +156,51 @@ test("a partially failed tree move rolls completed sessions back to their source
   }
 })
 
+test("a failed rollback refreshes routing and reports sessions that remain moved", async () => {
+  const source = "C:/one"
+  const destination = "C:/two"
+  const sessions = [session("root", source), session("child", source, "root")]
+  const [state, set] = createEngineState()
+  for (const entry of sessions) set("sessions", entry.id, entry)
+  const originalFetch = globalThis.fetch
+  let sourceLists = 0
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url)
+    if (url.pathname === "/experimental/session") {
+      const directory = url.searchParams.get("directory")
+      if (directory === source && sourceLists++ === 0) return Response.json(sessions)
+      if (directory === source) return Response.json([session("child", source, "root")])
+      return Response.json([session("root", destination)])
+    }
+    if (url.pathname === "/session/status") return Response.json({})
+    const body = (await request.json()) as { sessionID: string; destination: { directory: string } }
+    if (body.sessionID === "child")
+      return Response.json({ data: { message: "move rejected" } }, { status: 400 })
+    if (body.destination.directory === source)
+      return Response.json({ data: { message: "rollback rejected" } }, { status: 409 })
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+
+  try {
+    const actions = createActions(
+      () => ({}) as never,
+      state,
+      set,
+      () => ({ url: "http://engine.test" }),
+    )
+    expect(await actions.moveSession("root", destination)).toEqual({
+      ok: false,
+      moved: ["root"],
+      error: "move rejected. Rollback failed for root. Still moved: root",
+    })
+    expect(state.sessions.root.directory).toBe(destination)
+    expect(state.sessions.child.directory).toBe(source)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
 test("session move events update routing metadata and preserve transcript state", () => {
   const [state, set] = createEngineState()
   set("sessions", "root", session("root", "C:/one"))

--- a/tests/startup.test.ts
+++ b/tests/startup.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
 import type { Session } from "@opencode-ai/sdk/client"
 import { createActions } from "../src/engine/actions"
+import { resolveEngine } from "../src/engine/connection"
 import { createEngineState, putSessions } from "../src/engine/store"
 
 if (!("localStorage" in globalThis))
@@ -66,6 +67,29 @@ test("concurrent global session loads share one request", async () => {
 test("engine startup does not replace an active global event pump", async () => {
   const source = await Bun.file("src/engine/index.tsx").text()
   expect(source).toContain("if (!base || disposed || pumpAbort) return")
+})
+
+test("shell engine resolution refreshes a restarted target and credentials", async () => {
+  const original = (globalThis as { __TAURI__?: unknown }).__TAURI__
+  const statuses = [
+    { url: "http://127.0.0.1:4100", password: "first" },
+    { url: "http://127.0.0.1:4200", password: "second" },
+  ]
+  ;(globalThis as { __TAURI__?: unknown }).__TAURI__ = {
+    core: { invoke: async () => statuses.shift() },
+  }
+  try {
+    expect(await resolveEngine()).toEqual({
+      url: "http://127.0.0.1:4100",
+      headers: { Authorization: `Basic ${btoa("opencode:first")}` },
+    })
+    expect(await resolveEngine()).toEqual({
+      url: "http://127.0.0.1:4200",
+      headers: { Authorization: `Basic ${btoa("opencode:second")}` },
+    })
+  } finally {
+    ;(globalThis as { __TAURI__?: unknown }).__TAURI__ = original
+  }
 })
 
 test("startup splash waits for workspace bootstrap without trapping empty or failed startup", async () => {


### PR DESCRIPTION
## Summary
- supervise embedded engine crashes with bounded backoff, rotated credentials and target re-resolution, terminal diagnostics, and shutdown-safe exit handling
- require whole-tree idle confirmation before moving and add an overlay-backed server guard serialized against run creation
- replace destructive path purges with durable exact-ID deletion tombstones that support partial, idempotent startup/reconnect retries and safe path restoration

## Migration and design
- SQLite startup adds workspace.purge_staged_at and pending_session_delete with idempotent CREATE/ALTER migration
- removed workspaces remain path reservations until every staged session ID is confirmed deleted; restoring the path cancels owned tombstones
- OpenCode remains pristine; engine run-state/control-plane behavior is represented by engine/overlays/session-run-guard.patch

## Validation
- bun run typecheck
- bun run test (122 passed)
- bun run test:engine
- bun run build
- bun run build:engine
- cargo test --manifest-path src-tauri/Cargo.toml (19 passed)
- bun run build:native
- git diff --check
- verified engine/upstream and engine/.overlay-lock clean after overlay tests/build

## Note
Current rustfmt also proposes an unrelated assertion-only reflow in src-tauri/src/mcp.rs; that unrelated file was intentionally excluded.

Fixes #5
Fixes #6
Fixes #7