### PR TITLE
Fix spawn thread admission failures

### DIFF
--- a/engine/opencode/plugin/spawn-thread.ts
+++ b/engine/opencode/plugin/spawn-thread.ts
@@ -1,5 +1,18 @@
 import { tool, type Plugin } from "@opencode-ai/plugin"
 
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === "string" && error.trim()) return error
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>
+    for (const key of ["message", "error", "data"]) {
+      const detail = errorMessage(record[key], "")
+      if (detail) return detail
+    }
+  }
+  return fallback
+}
+
 export const SpawnThread: Plugin = async ({ client }) => ({
   tool: {
     spawn_thread: tool({
@@ -24,6 +37,18 @@ export const SpawnThread: Plugin = async ({ client }) => ({
         const session = created.data
         if (!session) return "Failed to spawn thread: session could not be created"
 
+        const failSpawn = async (failure: string): Promise<never> => {
+          try {
+            const deleted = await client.session.delete({ path: { id: session.id }, query: { directory } })
+            if (deleted.error !== undefined) throw deleted.error
+          } catch (cleanupError) {
+            throw new Error(
+              `${failure} Cleanup of child session ${session.id} also failed: ${errorMessage(cleanupError, "unknown cleanup error")}`,
+            )
+          }
+          throw new Error(failure)
+        }
+
         const history = await client.session.messages({ path: { id: ctx.sessionID }, query: { directory } })
         const lastAssistant = history.data?.findLast((entry) => entry.info.role === "assistant")?.info
         const model =
@@ -40,16 +65,28 @@ export const SpawnThread: Plugin = async ({ client }) => ({
           .filter(Boolean)
           .join("\n\n")
 
-        await client.session.promptAsync({
-          path: { id: session.id },
-          body: { parts: [{ type: "text", text: seed }], model, agent: ctx.agent },
-          query: { directory },
-        })
+        let prompted
+        try {
+          prompted = await client.session.promptAsync({
+            path: { id: session.id },
+            body: { parts: [{ type: "text", text: seed }], model, agent: ctx.agent },
+            query: { directory },
+          })
+        } catch (error) {
+          return failSpawn(
+            `Failed to start spawned thread "${args.title}": prompt request failed: ${errorMessage(error, "unknown transport error")}.`,
+          )
+        }
+        if (prompted.error !== undefined) {
+          return failSpawn(
+            `Failed to start spawned thread "${args.title}": seed prompt was rejected: ${errorMessage(prompted.error, "unknown admission error")}.`,
+          )
+        }
 
         return {
           title: `Spawned: ${args.title}`,
           output: [
-            `Spawned thread "${args.title}" (id ${session.id}) and it is now working on the task.`,
+            `Spawned thread "${args.title}" (id ${session.id}); its seed prompt was accepted for processing.`,
             "The user can open it from the sidebar and continue that conversation directly.",
             "Do not repeat the spawned task here; report back to the user that the thread was spawned.",
           ].join(" "),

--- a/engine/opencode/plugin/spawn-thread.ts
+++ b/engine/opencode/plugin/spawn-thread.ts
@@ -13,6 +13,10 @@ function errorMessage(error: unknown, fallback: string): string {
   return fallback
 }
 
+function messageID(): string {
+  return `msg_${crypto.randomUUID().replaceAll("-", "")}`
+}
+
 export const SpawnThread: Plugin = async ({ client }) => ({
   tool: {
     spawn_thread: tool({
@@ -49,32 +53,62 @@ export const SpawnThread: Plugin = async ({ client }) => ({
           throw new Error(failure)
         }
 
-        const history = await client.session.messages({ path: { id: ctx.sessionID }, query: { directory } })
-        const lastAssistant = history.data?.findLast((entry) => entry.info.role === "assistant")?.info
-        const model =
-          lastAssistant && "modelID" in lastAssistant
-            ? { providerID: lastAssistant.providerID, modelID: lastAssistant.modelID }
-            : undefined
+        let model: { providerID: string; modelID: string } | undefined
+        let seed: string
+        let seedMessageID: string
+        try {
+          const history = await client.session.messages({ path: { id: ctx.sessionID }, query: { directory } })
+          if (history.error !== undefined) throw history.error
+          const lastAssistant = history.data?.findLast((entry) => entry.info.role === "assistant")?.info
+          model =
+            lastAssistant && "modelID" in lastAssistant
+              ? { providerID: lastAssistant.providerID, modelID: lastAssistant.modelID }
+              : undefined
+          seed = [
+            "You are starting a thread that was spawned from another conversation. The context below was carried over for you.",
+            `## Carried context\n${args.summary}`,
+            args.context ? `## Excerpts\n${args.context}` : "",
+            `## Task\n${args.task}`,
+          ]
+            .filter(Boolean)
+            .join("\n\n")
+          seedMessageID = messageID()
+        } catch (error) {
+          return failSpawn(
+            `Failed to prepare spawned thread "${args.title}" before prompting: ${errorMessage(error, "unknown preparation error")}.`,
+          )
+        }
 
-        const seed = [
-          "You are starting a thread that was spawned from another conversation. The context below was carried over for you.",
-          `## Carried context\n${args.summary}`,
-          args.context ? `## Excerpts\n${args.context}` : "",
-          `## Task\n${args.task}`,
-        ]
-          .filter(Boolean)
-          .join("\n\n")
+        const spawned = () => ({
+          title: `Spawned: ${args.title}`,
+          output: [
+            `Spawned thread "${args.title}" (id ${session.id}); its seed prompt was accepted for processing.`,
+            "The user can open it from the sidebar and continue that conversation directly.",
+            "Do not repeat the spawned task here; report back to the user that the thread was spawned.",
+          ].join(" "),
+          metadata: { sessionId: session.id, spawned: true },
+        })
 
         let prompted
         try {
           prompted = await client.session.promptAsync({
             path: { id: session.id },
-            body: { parts: [{ type: "text", text: seed }], model, agent: ctx.agent },
+            body: { messageID: seedMessageID, parts: [{ type: "text", text: seed }], model, agent: ctx.agent },
             query: { directory },
           })
         } catch (error) {
-          return failSpawn(
-            `Failed to start spawned thread "${args.title}": prompt request failed: ${errorMessage(error, "unknown transport error")}.`,
+          const transportError = errorMessage(error, "unknown transport error")
+          try {
+            const admitted = await client.session.message({
+              path: { id: session.id, messageID: seedMessageID },
+              query: { directory },
+            })
+            if (admitted.data?.info.id === seedMessageID) return spawned()
+          } catch {
+            // The verification failure is secondary; the prompt request remains indeterminate.
+          }
+          throw new Error(
+            `Failed to confirm whether spawned thread "${args.title}" was started after a transport error: ${transportError}. Admission is unknown and retryable; child session ${session.id} was preserved. Check for seed message ${seedMessageID} before retrying.`,
           )
         }
         if (prompted.error !== undefined) {
@@ -83,15 +117,7 @@ export const SpawnThread: Plugin = async ({ client }) => ({
           )
         }
 
-        return {
-          title: `Spawned: ${args.title}`,
-          output: [
-            `Spawned thread "${args.title}" (id ${session.id}); its seed prompt was accepted for processing.`,
-            "The user can open it from the sidebar and continue that conversation directly.",
-            "Do not repeat the spawned task here; report back to the user that the thread was spawned.",
-          ].join(" "),
-          metadata: { sessionId: session.id, spawned: true },
-        }
+        return spawned()
       },
     }),
   },

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -4,6 +4,101 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { buildExtensions } from "../scripts/build-extensions"
+import { SpawnThread } from "../engine/opencode/plugin/spawn-thread"
+
+const args = {
+  title: "Child thread",
+  task: "Investigate the failure",
+  summary: "The parent encountered a failure.",
+}
+
+const context = {
+  sessionID: "parent",
+  messageID: "message",
+  agent: "build",
+  directory: "C:/workspace",
+  worktree: "C:/workspace",
+  abort: new AbortController().signal,
+  metadata() {},
+  async ask() {},
+}
+
+async function spawnTool(options?: {
+  promptAsync?: () => Promise<unknown>
+  delete?: () => Promise<unknown>
+}) {
+  const deleted: string[] = []
+  const client = {
+    session: {
+      async create() {
+        return { data: { id: "child" } }
+      },
+      async messages() {
+        return { data: [] }
+      },
+      promptAsync: options?.promptAsync ?? (async () => ({ data: undefined })),
+      delete:
+        options?.delete ??
+        (async ({ path: input }: { path: { id: string } }) => {
+          deleted.push(input.id)
+          return { data: true }
+        }),
+    },
+  }
+  const plugin = await SpawnThread({ client } as never)
+  const execute = plugin.tool?.spawn_thread.execute
+  if (!execute) throw new Error("spawn_thread tool was not registered")
+  return { deleted, execute: () => execute(args, context) }
+}
+
+test("spawn_thread reports only prompt admission after a successful 204", async () => {
+  const spawn = await spawnTool()
+  const result = await spawn.execute()
+  expect(result).toMatchObject({
+    metadata: { sessionId: "child", spawned: true },
+  })
+  expect(result).toHaveProperty("output", expect.stringContaining("seed prompt was accepted for processing"))
+  expect(JSON.stringify(result)).not.toContain("working on the task")
+  expect(spawn.deleted).toEqual([])
+})
+
+test("spawn_thread rejects SDK admission errors and removes the child", async () => {
+  const spawn = await spawnTool({
+    promptAsync: async () => ({ error: { data: { message: "model is unavailable" } } }),
+  })
+  await expect(spawn.execute()).rejects.toThrow("seed prompt was rejected: model is unavailable")
+  expect(spawn.deleted).toEqual(["child"])
+})
+
+test("spawn_thread rejects thrown prompt requests and removes the child", async () => {
+  const spawn = await spawnTool({
+    promptAsync: async () => {
+      throw new Error("connection reset")
+    },
+  })
+  await expect(spawn.execute()).rejects.toThrow("prompt request failed: connection reset")
+  expect(spawn.deleted).toEqual(["child"])
+})
+
+test("spawn_thread preserves transport and cleanup failures", async () => {
+  const spawn = await spawnTool({
+    promptAsync: async () => {
+      throw new Error("connection reset")
+    },
+    delete: async () => ({ error: { message: "delete denied" } }),
+  })
+  await expect(spawn.execute()).rejects.toThrow(
+    'prompt request failed: connection reset. Cleanup of child session child also failed: delete denied',
+  )
+})
+
+test("spawn_thread failures never return spawned success or leave a removable orphan", async () => {
+  const spawn = await spawnTool({ promptAsync: async () => ({ error: "bad request" }) })
+  const outcome = await spawn.execute().catch((error) => error)
+  expect(outcome).toBeInstanceOf(Error)
+  expect(outcome).not.toHaveProperty("metadata.spawned", true)
+  expect(spawn.deleted).toEqual(["child"])
+})
 
 test("release extensions load without workspace node_modules", async () => {
   const output = mkdtempSync(path.join(tmpdir(), "drift-extensions-"))

--- a/tests/extensions.test.ts
+++ b/tests/extensions.test.ts
@@ -24,19 +24,24 @@ const context = {
 }
 
 async function spawnTool(options?: {
-  promptAsync?: () => Promise<unknown>
+  messages?: () => Promise<unknown>
+  promptAsync?: (input: unknown) => Promise<unknown>
+  message?: (input: unknown) => Promise<unknown>
   delete?: () => Promise<unknown>
 }) {
   const deleted: string[] = []
+  const prompted: unknown[] = []
   const client = {
     session: {
       async create() {
         return { data: { id: "child" } }
       },
-      async messages() {
-        return { data: [] }
+      messages: options?.messages ?? (async () => ({ data: [] })),
+      async promptAsync(input: unknown) {
+        prompted.push(input)
+        return options?.promptAsync ? options.promptAsync(input) : { data: undefined }
       },
-      promptAsync: options?.promptAsync ?? (async () => ({ data: undefined })),
+      message: options?.message ?? (async () => ({ error: { message: "message not found" } })),
       delete:
         options?.delete ??
         (async ({ path: input }: { path: { id: string } }) => {
@@ -48,7 +53,7 @@ async function spawnTool(options?: {
   const plugin = await SpawnThread({ client } as never)
   const execute = plugin.tool?.spawn_thread.execute
   if (!execute) throw new Error("spawn_thread tool was not registered")
-  return { deleted, execute: () => execute(args, context) }
+  return { deleted, prompted, execute: () => execute(args, context) }
 }
 
 test("spawn_thread reports only prompt admission after a successful 204", async () => {
@@ -70,34 +75,62 @@ test("spawn_thread rejects SDK admission errors and removes the child", async ()
   expect(spawn.deleted).toEqual(["child"])
 })
 
-test("spawn_thread rejects thrown prompt requests and removes the child", async () => {
+test("spawn_thread verifies admission after an ambiguous transport failure", async () => {
+  let promptedMessageID = ""
+  let verifiedMessageID = ""
+  const spawn = await spawnTool({
+    promptAsync: async (input) => {
+      promptedMessageID = (input as { body: { messageID: string } }).body.messageID
+      throw new Error("connection reset")
+    },
+    message: async (input) => {
+      verifiedMessageID = (input as { path: { messageID: string } }).path.messageID
+      return { data: { info: { id: verifiedMessageID, role: "user" }, parts: [] } }
+    },
+  })
+  const result = await spawn.execute()
+  expect(promptedMessageID).toStartWith("msg_")
+  expect(verifiedMessageID).toBe(promptedMessageID)
+  expect(result).toMatchObject({ metadata: { sessionId: "child", spawned: true } })
+  expect(spawn.deleted).toEqual([])
+})
+
+test("spawn_thread preserves the child when transport admission remains unknown", async () => {
   const spawn = await spawnTool({
     promptAsync: async () => {
       throw new Error("connection reset")
     },
   })
-  await expect(spawn.execute()).rejects.toThrow("prompt request failed: connection reset")
-  expect(spawn.deleted).toEqual(["child"])
+  const error = await spawn.execute().catch((failure) => failure)
+  expect(error).toBeInstanceOf(Error)
+  expect(error.message).toContain("Admission is unknown and retryable; child session child was preserved")
+  expect(error.message).toContain("Check for seed message msg_")
+  expect(spawn.deleted).toEqual([])
 })
 
-test("spawn_thread preserves transport and cleanup failures", async () => {
+test("spawn_thread cleans up when parent history retrieval throws before prompting", async () => {
   const spawn = await spawnTool({
-    promptAsync: async () => {
-      throw new Error("connection reset")
+    messages: async () => {
+      throw new Error("history unavailable")
     },
-    delete: async () => ({ error: { message: "delete denied" } }),
   })
   await expect(spawn.execute()).rejects.toThrow(
-    'prompt request failed: connection reset. Cleanup of child session child also failed: delete denied',
+    'Failed to prepare spawned thread "Child thread" before prompting: history unavailable.',
   )
+  expect(spawn.prompted).toEqual([])
+  expect(spawn.deleted).toEqual(["child"])
 })
 
-test("spawn_thread failures never return spawned success or leave a removable orphan", async () => {
-  const spawn = await spawnTool({ promptAsync: async () => ({ error: "bad request" }) })
-  const outcome = await spawn.execute().catch((error) => error)
-  expect(outcome).toBeInstanceOf(Error)
-  expect(outcome).not.toHaveProperty("metadata.spawned", true)
-  expect(spawn.deleted).toEqual(["child"])
+test("spawn_thread preserves preparation and cleanup error context", async () => {
+  const spawn = await spawnTool({
+    messages: async () => {
+      throw new Error("history unavailable")
+    },
+    delete: async () => ({ error: { data: { message: "delete denied" } } }),
+  })
+  await expect(spawn.execute()).rejects.toThrow(
+    'before prompting: history unavailable. Cleanup of child session child also failed: delete denied',
+  )
 })
 
 test("release extensions load without workspace node_modules", async () => {


### PR DESCRIPTION
## Summary
- validate spawn_thread prompt admission results and fail on SDK or transport errors
- clean up newly created children on failed admission while retaining cleanup context
- report successful prompt admission without implying model completion
- add extension coverage for success and failure cleanup paths

## Validation
- bun test tests/extensions.test.ts
- bun test tests
- bun run typecheck
- bun run build

Fixes #10