### PR TITLE
Harden release validation and tag policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,16 @@ jobs:
       commit: ${{ steps.policy.outputs.commit }}
       version: ${{ steps.policy.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.sha }}
 
       - name: Fetch release policy refs
         run: git fetch --force origin master:refs/remotes/origin/master "+refs/tags/*:refs/tags/*"
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 
@@ -34,23 +35,24 @@ jobs:
         id: policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: bun scripts/release-policy.ts check "$GITHUB_REF_NAME"
+        run: bun scripts/release-policy.ts check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"
 
   validation:
     needs: tag-policy
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           ref: ${{ needs.tag-policy.outputs.commit }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           workspaces: src-tauri
 
@@ -81,25 +83,26 @@ jobs:
       - name: Production UI and package assembly
         run: bun run build:native
 
-  publish:
+  signed-artifacts:
     needs: [tag-policy, validation]
     runs-on: windows-latest
     permissions:
-      contents: write
+      contents: read
       models: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ needs.tag-policy.outputs.commit }}
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           workspaces: src-tauri
 
@@ -150,16 +153,80 @@ jobs:
           RELEASE_NOTES_MODEL: openai/gpt-4.1
         run: bun scripts/release-notes.ts release-notes.md
 
+      - name: Bind release to this workflow event
+        shell: pwsh
+        run: |
+          Add-Content release-notes.md "`n<!-- drift-release: run=${{ github.run_id }} commit=${{ needs.tag-policy.outputs.commit }} -->"
+
+      - name: Upload signed release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-${{ github.run_id }}-${{ needs.tag-policy.outputs.commit }}
+          path: |
+            src-tauri/target/release/bundle/nsis/*-setup.exe
+            src-tauri/target/release/bundle/nsis/*.sig
+            src-tauri/target/release/bundle/nsis/latest.json
+            release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: [tag-policy, validation, signed-artifacts]
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download signed release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-${{ github.run_id }}-${{ needs.tag-policy.outputs.commit }}
+          path: release-artifacts
+
+      - name: Revalidate tag and existing release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $commit = "${{ needs.tag-policy.outputs.commit }}".ToLowerInvariant()
+          $remoteRefs = @{}
+          git ls-remote "https://github.com/${{ github.repository }}.git" "refs/tags/$tag" "refs/tags/$tag^{}" | ForEach-Object {
+            $sha, $ref = $_ -split "\s+"
+            $remoteRefs[$ref] = $sha.ToLowerInvariant()
+          }
+          $resolved = $remoteRefs["refs/tags/$tag^{}"]
+          if (-not $resolved) { $resolved = $remoteRefs["refs/tags/$tag"] }
+          if ($resolved -ne $commit) { throw "$tag no longer resolves to triggering commit $commit" }
+
+          $headers = @{
+            Accept = "application/vnd.github+json"
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+          try {
+            $release = Invoke-RestMethod "https://api.github.com/repos/${{ github.repository }}/releases/tags/$tag" -Headers $headers
+          } catch {
+            if ([int]$_.Exception.Response.StatusCode -ne 404) { throw }
+          }
+          if ($release) {
+            $marker = "<!-- drift-release: run=${{ github.run_id }} commit=$commit -->"
+            if (-not ($release.body -and $release.body.Contains($marker))) {
+              throw "$tag already has a release from another commit or workflow run"
+            }
+          }
+
       - name: Publish stable GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           name: Drift ${{ github.ref_name }}
-          body_path: release-notes.md
+          body_path: release-artifacts/release-notes.md
+          target_commitish: ${{ needs.tag-policy.outputs.commit }}
           draft: false
           prerelease: false
           make_latest: true
           overwrite_files: true
+          fail_on_unmatched_files: true
           files: |
-            src-tauri/target/release/bundle/nsis/*-setup.exe
-            src-tauri/target/release/bundle/nsis/*.sig
-            src-tauri/target/release/bundle/nsis/latest.json
+            release-artifacts/*-setup.exe
+            release-artifacts/*.sig
+            release-artifacts/latest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: stable-release
   cancel-in-progress: false
 
 jobs:
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       commit: ${{ steps.policy.outputs.commit }}
+      published: ${{ steps.policy.outputs.published }}
       version: ${{ steps.policy.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,7 +30,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Validate stable release tag
         id: policy
@@ -39,6 +40,7 @@ jobs:
 
   validation:
     needs: tag-policy
+    if: needs.tag-policy.outputs.published != 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
 
@@ -85,6 +87,7 @@ jobs:
 
   signed-artifacts:
     needs: [tag-policy, validation]
+    if: needs.tag-policy.outputs.published != 'true'
     runs-on: windows-latest
     permissions:
       contents: read
@@ -98,7 +101,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
 
@@ -153,15 +156,15 @@ jobs:
           RELEASE_NOTES_MODEL: openai/gpt-4.1
         run: bun scripts/release-notes.ts release-notes.md
 
-      - name: Bind release to this workflow event
-        shell: pwsh
-        run: |
-          Add-Content release-notes.md "`n<!-- drift-release: run=${{ github.run_id }} commit=${{ needs.tag-policy.outputs.commit }} -->"
+      - name: Seal release notes and asset digests
+        run: >-
+          bun scripts/release-policy.ts seal release-notes.md "$env:GITHUB_RUN_ID"
+          "${{ needs.tag-policy.outputs.commit }}" "src-tauri/target/release/bundle/nsis"
 
       - name: Upload signed release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: release-${{ github.run_id }}-${{ needs.tag-policy.outputs.commit }}
+          name: release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.tag-policy.outputs.commit }}
           path: |
             src-tauri/target/release/bundle/nsis/*-setup.exe
             src-tauri/target/release/bundle/nsis/*.sig
@@ -172,50 +175,38 @@ jobs:
 
   publish:
     needs: [tag-policy, validation, signed-artifacts]
+    if: needs.tag-policy.outputs.published != 'true'
     runs-on: windows-latest
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.tag-policy.outputs.commit }}
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: 1.3.14
+
       - name: Download signed release artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: release-${{ github.run_id }}-${{ needs.tag-policy.outputs.commit }}
+          name: release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.tag-policy.outputs.commit }}
           path: release-artifacts
 
-      - name: Revalidate tag and existing release
-        shell: pwsh
+      - name: Fetch current release policy refs
+        run: git fetch --force origin master:refs/remotes/origin/master "+refs/tags/*:refs/tags/*"
+
+      - name: Revalidate complete release policy
+        id: final-policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          $tag = "${{ github.ref_name }}"
-          $commit = "${{ needs.tag-policy.outputs.commit }}".ToLowerInvariant()
-          $remoteRefs = @{}
-          git ls-remote "https://github.com/${{ github.repository }}.git" "refs/tags/$tag" "refs/tags/$tag^{}" | ForEach-Object {
-            $sha, $ref = $_ -split "\s+"
-            $remoteRefs[$ref] = $sha.ToLowerInvariant()
-          }
-          $resolved = $remoteRefs["refs/tags/$tag^{}"]
-          if (-not $resolved) { $resolved = $remoteRefs["refs/tags/$tag"] }
-          if ($resolved -ne $commit) { throw "$tag no longer resolves to triggering commit $commit" }
-
-          $headers = @{
-            Accept = "application/vnd.github+json"
-            Authorization = "Bearer $env:GITHUB_TOKEN"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-          try {
-            $release = Invoke-RestMethod "https://api.github.com/repos/${{ github.repository }}/releases/tags/$tag" -Headers $headers
-          } catch {
-            if ([int]$_.Exception.Response.StatusCode -ne 404) { throw }
-          }
-          if ($release) {
-            $marker = "<!-- drift-release: run=${{ github.run_id }} commit=$commit -->"
-            if (-not ($release.body -and $release.body.Contains($marker))) {
-              throw "$tag already has a release from another commit or workflow run"
-            }
-          }
+        run: bun scripts/release-policy.ts check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"
 
       - name: Publish stable GitHub release
+        if: steps.final-policy.outputs.published != 'true'
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           name: Drift ${{ github.ref_name }}
@@ -224,7 +215,6 @@ jobs:
           draft: false
           prerelease: false
           make_latest: true
-          overwrite_files: true
           fail_on_unmatched_files: true
           files: |
             release-artifacts/*-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,44 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
-  models: read
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  windows:
-    runs-on: windows-latest
+  tag-policy:
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.policy.outputs.commit }}
+      version: ${{ steps.policy.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Fetch release policy refs
+        run: git fetch --force origin master:refs/remotes/origin/master "+refs/tags/*:refs/tags/*"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Validate stable release tag
+        id: policy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun scripts/release-policy.ts check "$GITHUB_REF_NAME"
+
+  validation:
+    needs: tag-policy
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag-policy.outputs.commit }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -36,28 +60,60 @@ jobs:
           bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
           bun install --frozen-lockfile --cwd engine/opencode
 
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Root tests
+        run: bun run test
+
+      - name: Engine integration tests
+        run: bun run test:engine
+
       - name: Build engine
         run: bun run build:engine
 
-      - name: Stamp version from tag
-        shell: pwsh
+      - name: Native unit tests
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml
+
+      - name: Stamp release version
+        run: bun scripts/release-policy.ts stamp "$env:GITHUB_REF_NAME"
+
+      - name: Production UI and package assembly
+        run: bun run build:native
+
+  publish:
+    needs: [tag-policy, validation]
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      models: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.tag-policy.outputs.commit }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
-          if ($version -notmatch '^\d+\.\d+\.\d+') {
-            throw "Tag must look like v1.2.3, got ${{ github.ref_name }}"
-          }
+          bun install --frozen-lockfile
+          bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
+          bun install --frozen-lockfile --cwd engine/opencode
 
-          $pkg = Get-Content package.json -Raw | ConvertFrom-Json
-          $pkg.version = $version
-          $pkg | ConvertTo-Json -Depth 32 | Set-Content package.json -Encoding utf8
+      - name: Stamp release version
+        run: bun scripts/release-policy.ts stamp "$env:GITHUB_REF_NAME"
 
-          $cargo = Get-Content src-tauri/Cargo.toml -Raw
-          $cargo = $cargo -replace '(?m)^version = ".*"$', "version = `"$version`""
-          Set-Content src-tauri/Cargo.toml $cargo -Encoding utf8NoBOM
-
-          $conf = Get-Content src-tauri/tauri.conf.json -Raw | ConvertFrom-Json
-          $conf.version = $version
-          $conf | ConvertTo-Json -Depth 32 | Set-Content src-tauri/tauri.conf.json -Encoding utf8
+      - name: Build engine
+        run: bun run build:engine
 
       - name: Build signed installer
         env:
@@ -68,7 +124,7 @@ jobs:
       - name: Write update manifest
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart("v")
+          $version = "${{ needs.tag-policy.outputs.version }}"
           $bundle = "src-tauri/target/release/bundle/nsis"
           $sigFile = Get-ChildItem "$bundle/*.sig" | Select-Object -First 1
           $exeFile = Get-ChildItem "$bundle/*-setup.exe" | Select-Object -First 1
@@ -94,11 +150,15 @@ jobs:
           RELEASE_NOTES_MODEL: openai/gpt-4.1
         run: bun scripts/release-notes.ts release-notes.md
 
-      - name: Publish GitHub Release
+      - name: Publish stable GitHub release
         uses: softprops/action-gh-release@v2
         with:
           name: Drift ${{ github.ref_name }}
           body_path: release-notes.md
+          draft: false
+          prerelease: false
+          make_latest: true
+          overwrite_files: true
           files: |
             src-tauri/target/release/bundle/nsis/*-setup.exe
             src-tauri/target/release/bundle/nsis/*.sig

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,10 +98,12 @@ inside `engine/upstream/`. The full runbook is in [docs/engine.md](docs/engine.m
 
 ## Releases
 
-Releases are maintainer-only and run from tags matching `v*`. The workflow stamps the
-version from a tag such as `v1.2.3`, builds the engine and NSIS installer on Windows,
-signs the updater artifact, and publishes the installer, signature, and `latest.json`
-manifest to GitHub Releases.
+Releases are maintainer-only. A release tag must match `vMAJOR.MINOR.PATCH` exactly, point
+to a commit contained in `origin/master`, and be strictly newer than every other stable
+GitHub release or repository tag. Prerelease and build suffixes are not supported. Before
+signing, the workflow checks the tag policy and runs frozen installs, typechecking, root
+and engine tests, the engine build, Rust tests, and an unsigned production package build
+on the exact tag commit. Only the dependent publish job can access signing secrets.
 
 The repository must provide these GitHub Actions secrets:
 
@@ -112,7 +114,8 @@ The private key must match the public key in `src-tauri/tauri.conf.json`. It is 
 for every future update and must never be committed or included in workflow logs. Do not
 rotate the updater key without a migration plan for already-installed copies.
 
-After the standard checks pass, push the release tag:
+After the tagged commit is merged to `master` and the standard checks pass, choose a
+version newer than the latest stable release/tag and push the release tag:
 
 ```bash
 git tag v1.2.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,13 @@ to a commit contained in `origin/master`, and be strictly newer than every other
 GitHub release or repository tag. Prerelease and build suffixes are not supported. Before
 signing, the workflow checks the tag policy and runs frozen installs, typechecking, root
 and engine tests, the engine build, Rust tests, and an unsigned production package build
-on the exact tag commit. Only the dependent publish job can access signing secrets.
+on the exact tag commit. The signing job has read-only repository access, and only the
+separate publication job has contents write access.
+
+Stable releases are serialized across all tags. Published notes and assets are immutable:
+a rerun verifies the original workflow marker and asset SHA-256 manifest, then exits
+without rebuilding or publishing. Any mismatch requires investigation rather than an
+overwrite.
 
 The repository must provide these GitHub Actions secrets:
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:native": "tauri build --no-bundle",
     "package": "tauri build",
     "test": "bun test tests",
+    "test:release-policy": "bun test tests/release-policy.test.ts",
     "test:engine": "bun scripts/test-engine.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -17,7 +17,7 @@ export type GitHubRelease = {
   assets?: GitHubReleaseAsset[]
 }
 
-export const stableTagPattern = /^v\d+\.\d+\.\d+$/
+export const stableTagPattern = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/
 
 export function versionFromTag(tag: string) {
   if (!stableTagPattern.test(tag)) throw new Error(`Tag must match vMAJOR.MINOR.PATCH exactly, got ${tag}`)

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 
 export type GitHubRelease = {
   tag_name?: string
+  body?: string | null
   draft?: boolean
   prerelease?: boolean
 }
@@ -48,14 +49,35 @@ export function assertVersionIsNewer(currentTag: string, latestTag: string | und
   }
 }
 
+export function releaseRunMarker(runId: string, commit: string) {
+  return `<!-- drift-release: run=${runId} commit=${commit.toLowerCase()} -->`
+}
+
 export function validateReleasePolicy(input: {
   tag: string
+  triggerCommit: string
+  resolvedCommit: string
+  runId: string
   containedInMaster: boolean
   tags: string[]
   releases: GitHubRelease[]
 }) {
   const version = versionFromTag(input.tag)
+  const triggerCommit = input.triggerCommit.toLowerCase()
+  const resolvedCommit = input.resolvedCommit.toLowerCase()
+  if (resolvedCommit !== triggerCommit) {
+    throw new Error(`${input.tag} resolves to ${resolvedCommit}, not triggering commit ${triggerCommit}`)
+  }
   if (!input.containedInMaster) throw new Error(`${input.tag} commit is not contained in origin/master`)
+
+  const existing = input.releases.find((release) => release.tag_name === input.tag)
+  if (existing) {
+    const sameRunAndCommit = existing.body?.includes(releaseRunMarker(input.runId, triggerCommit))
+    if (!sameRunAndCommit) {
+      throw new Error(`${input.tag} already has a release from another commit or workflow run`)
+    }
+  }
+
   const latest = latestStableTag(input.tags, input.releases, input.tag)
   assertVersionIsNewer(input.tag, latest)
   return { version, latest }
@@ -118,10 +140,10 @@ export function stampReleaseVersion(tag: string, root = path.resolve(import.meta
   return version
 }
 
-async function checkPolicy(tag: string) {
+async function checkPolicy(tag: string, triggerCommit: string, runId: string) {
   const repository = process.env.GITHUB_REPOSITORY
   const token = process.env.GITHUB_TOKEN
-  if (!repository || !token) throw new Error("Missing GitHub release environment")
+  if (!repository || !token || !triggerCommit || !runId) throw new Error("Missing GitHub release environment")
 
   versionFromTag(tag)
   const commit = git(["rev-parse", `${tag}^{commit}`]).output
@@ -129,6 +151,9 @@ async function checkPolicy(tag: string) {
   const tags = git(["tag", "--list"]).output.split("\n").filter(Boolean)
   const result = validateReleasePolicy({
     tag,
+    triggerCommit,
+    resolvedCommit: commit,
+    runId,
     containedInMaster,
     tags,
     releases: await githubReleases(repository, token),
@@ -140,9 +165,9 @@ async function checkPolicy(tag: string) {
 }
 
 if (import.meta.main) {
-  const [command, tag] = process.argv.slice(2)
+  const [command, tag, triggerCommit, runId] = process.argv.slice(2)
   if (!tag) throw new Error("Usage: bun scripts/release-policy.ts <check|stamp> <tag>")
-  if (command === "check") await checkPolicy(tag)
+  if (command === "check") await checkPolicy(tag, triggerCommit, runId)
   else if (command === "stamp") console.log(`Stamped release version ${stampReleaseVersion(tag)}`)
   else throw new Error(`Unknown release policy command: ${command}`)
 }

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -1,0 +1,148 @@
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+export type GitHubRelease = {
+  tag_name?: string
+  draft?: boolean
+  prerelease?: boolean
+}
+
+export const stableTagPattern = /^v\d+\.\d+\.\d+$/
+
+export function versionFromTag(tag: string) {
+  if (!stableTagPattern.test(tag)) throw new Error(`Tag must match vMAJOR.MINOR.PATCH exactly, got ${tag}`)
+  return tag.slice(1)
+}
+
+function versionParts(tag: string) {
+  return versionFromTag(tag).split(".").map(BigInt)
+}
+
+export function compareStableTags(left: string, right: string) {
+  const leftParts = versionParts(left)
+  const rightParts = versionParts(right)
+  for (let index = 0; index < leftParts.length; index++) {
+    if (leftParts[index] < rightParts[index]) return -1
+    if (leftParts[index] > rightParts[index]) return 1
+  }
+  return 0
+}
+
+export function latestStableTag(tags: string[], releases: GitHubRelease[], currentTag: string) {
+  const candidates = [
+    ...tags,
+    ...releases
+      .filter((release) => !release.draft && !release.prerelease)
+      .map((release) => release.tag_name ?? ""),
+  ].filter((tag) => tag !== currentTag && stableTagPattern.test(tag))
+
+  return candidates.reduce<string | undefined>((latest, tag) => {
+    return !latest || compareStableTags(tag, latest) > 0 ? tag : latest
+  }, undefined)
+}
+
+export function assertVersionIsNewer(currentTag: string, latestTag: string | undefined) {
+  versionFromTag(currentTag)
+  if (latestTag && compareStableTags(currentTag, latestTag) <= 0) {
+    throw new Error(`${currentTag} must be newer than latest stable release/tag ${latestTag}`)
+  }
+}
+
+export function validateReleasePolicy(input: {
+  tag: string
+  containedInMaster: boolean
+  tags: string[]
+  releases: GitHubRelease[]
+}) {
+  const version = versionFromTag(input.tag)
+  if (!input.containedInMaster) throw new Error(`${input.tag} commit is not contained in origin/master`)
+  const latest = latestStableTag(input.tags, input.releases, input.tag)
+  assertVersionIsNewer(input.tag, latest)
+  return { version, latest }
+}
+
+function git(args: string[], allowFailure = false) {
+  const result = Bun.spawnSync({ cmd: ["git", ...args], stdout: "pipe", stderr: "pipe" })
+  if (!allowFailure && result.exitCode !== 0) {
+    throw new Error(result.stderr.toString().trim() || `git ${args.join(" ")} failed`)
+  }
+  return { exitCode: result.exitCode, output: result.stdout.toString().trim() }
+}
+
+async function githubReleases(repository: string, token: string) {
+  const releases: GitHubRelease[] = []
+  for (let page = 1; ; page++) {
+    const response = await fetch(`https://api.github.com/repos/${repository}/releases?per_page=100&page=${page}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    })
+    if (!response.ok) throw new Error(`GitHub releases API ${response.status}: ${await response.text()}`)
+    const pageReleases = await response.json() as GitHubRelease[]
+    releases.push(...pageReleases)
+    if (pageReleases.length < 100) return releases
+  }
+}
+
+function replaceRequired(content: string, pattern: RegExp, replacement: string, file: string) {
+  if (!pattern.test(content)) throw new Error(`Could not stamp version in ${file}`)
+  return content.replace(pattern, replacement)
+}
+
+export function stampReleaseVersion(tag: string, root = path.resolve(import.meta.dirname, "..")) {
+  const version = versionFromTag(tag)
+  for (const relative of ["package.json", "src-tauri/tauri.conf.json"]) {
+    const file = path.join(root, relative)
+    const contents = JSON.parse(readFileSync(file, "utf8")) as { version: string }
+    contents.version = version
+    writeFileSync(file, `${JSON.stringify(contents, null, 2)}\n`)
+  }
+
+  const cargoManifest = path.join(root, "src-tauri/Cargo.toml")
+  writeFileSync(cargoManifest, replaceRequired(
+    readFileSync(cargoManifest, "utf8"),
+    /(^\[package\][\s\S]*?^version = ")[^"]+("$)/m,
+    `$1${version}$2`,
+    cargoManifest,
+  ))
+
+  const cargoLock = path.join(root, "src-tauri/Cargo.lock")
+  writeFileSync(cargoLock, replaceRequired(
+    readFileSync(cargoLock, "utf8"),
+    /(^\[\[package\]\]\r?\nname = "drift"\r?\nversion = ")[^"]+("$)/m,
+    `$1${version}$2`,
+    cargoLock,
+  ))
+  return version
+}
+
+async function checkPolicy(tag: string) {
+  const repository = process.env.GITHUB_REPOSITORY
+  const token = process.env.GITHUB_TOKEN
+  if (!repository || !token) throw new Error("Missing GitHub release environment")
+
+  versionFromTag(tag)
+  const commit = git(["rev-parse", `${tag}^{commit}`]).output
+  const containedInMaster = git(["merge-base", "--is-ancestor", commit, "refs/remotes/origin/master"], true).exitCode === 0
+  const tags = git(["tag", "--list"]).output.split("\n").filter(Boolean)
+  const result = validateReleasePolicy({
+    tag,
+    containedInMaster,
+    tags,
+    releases: await githubReleases(repository, token),
+  })
+
+  const output = process.env.GITHUB_OUTPUT
+  if (output) appendFileSync(output, `version=${result.version}\ncommit=${commit}\n`)
+  console.log(`${tag} (${commit}) is eligible; previous stable tag is ${result.latest ?? "none"}`)
+}
+
+if (import.meta.main) {
+  const [command, tag] = process.argv.slice(2)
+  if (!tag) throw new Error("Usage: bun scripts/release-policy.ts <check|stamp> <tag>")
+  if (command === "check") await checkPolicy(tag)
+  else if (command === "stamp") console.log(`Stamped release version ${stampReleaseVersion(tag)}`)
+  else throw new Error(`Unknown release policy command: ${command}`)
+}

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -1,11 +1,20 @@
-import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
+import { createHash } from "node:crypto"
+import { appendFileSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import path from "node:path"
+
+export type GitHubReleaseAsset = {
+  name?: string
+  state?: string
+  size?: number
+  digest?: string | null
+}
 
 export type GitHubRelease = {
   tag_name?: string
   body?: string | null
   draft?: boolean
   prerelease?: boolean
+  assets?: GitHubReleaseAsset[]
 }
 
 export const stableTagPattern = /^v\d+\.\d+\.\d+$/
@@ -53,6 +62,75 @@ export function releaseRunMarker(runId: string, commit: string) {
   return `<!-- drift-release: run=${runId} commit=${commit.toLowerCase()} -->`
 }
 
+type ReleaseAssetDigest = { name: string; digest: string }
+
+const sha256Pattern = /^sha256:[0-9a-f]{64}$/
+const releaseAssetsMarkerPattern = /<!-- drift-release-assets: ([A-Za-z0-9_-]+) -->/g
+
+export function releaseAssetsMarker(assets: ReleaseAssetDigest[]) {
+  const sorted = [...assets].sort((left, right) => left.name.localeCompare(right.name))
+  if (new Set(sorted.map((asset) => asset.name)).size !== sorted.length) {
+    throw new Error("Release asset manifest contains duplicate names")
+  }
+  for (const asset of sorted) {
+    if (!asset.name || !sha256Pattern.test(asset.digest)) {
+      throw new Error(`Invalid release asset manifest entry for ${asset.name || "unnamed asset"}`)
+    }
+  }
+  return `<!-- drift-release-assets: ${Buffer.from(JSON.stringify(sorted)).toString("base64url")} -->`
+}
+
+function expectedReleaseAssetNames(assets: { name: string }[]) {
+  const installers = assets.filter((asset) => asset.name.endsWith("-setup.exe"))
+  if (installers.length !== 1) throw new Error("Published release must contain exactly one setup executable")
+  return [installers[0].name, `${installers[0].name}.sig`, "latest.json"].sort()
+}
+
+export function validatePublishedRelease(release: GitHubRelease, runId: string, commit: string) {
+  if (release.draft || release.prerelease) throw new Error("Existing stable release is draft or prerelease")
+
+  const body = release.body ?? ""
+  const runMarker = releaseRunMarker(runId, commit)
+  if (body.split(runMarker).length !== 2) {
+    throw new Error(`${release.tag_name} already has a release from another commit or workflow run`)
+  }
+
+  const markerMatches = [...body.matchAll(releaseAssetsMarkerPattern)]
+  if (markerMatches.length !== 1) throw new Error("Published release must contain exactly one immutable asset manifest")
+
+  let manifest: ReleaseAssetDigest[]
+  try {
+    manifest = JSON.parse(Buffer.from(markerMatches[0][1], "base64url").toString("utf8"))
+  } catch {
+    throw new Error("Published release has an invalid immutable asset manifest")
+  }
+  if (!Array.isArray(manifest)) throw new Error("Published release has an invalid immutable asset manifest")
+  releaseAssetsMarker(manifest)
+
+  const assets = (release.assets ?? []).map((asset) => ({
+    name: asset.name ?? "",
+    state: asset.state,
+    size: asset.size,
+    digest: asset.digest?.toLowerCase() ?? "",
+  }))
+  const expectedNames = expectedReleaseAssetNames(assets)
+  const actualNames = assets.map((asset) => asset.name).sort()
+  if (actualNames.length !== expectedNames.length || actualNames.some((name, index) => name !== expectedNames[index])) {
+    throw new Error("Published release assets do not match the required installer, signature, and update manifest")
+  }
+
+  const digests = new Map(manifest.map((asset) => [asset.name, asset.digest]))
+  for (const asset of assets) {
+    if (asset.state !== "uploaded" || !asset.size || !sha256Pattern.test(asset.digest)) {
+      throw new Error(`Published release asset ${asset.name} is incomplete or missing its SHA-256 digest`)
+    }
+    if (digests.get(asset.name) !== asset.digest) {
+      throw new Error(`Published release asset ${asset.name} does not match its immutable digest`)
+    }
+  }
+  if (digests.size !== assets.length) throw new Error("Published release asset manifest does not match published assets")
+}
+
 export function validateReleasePolicy(input: {
   tag: string
   triggerCommit: string
@@ -72,15 +150,13 @@ export function validateReleasePolicy(input: {
 
   const existing = input.releases.find((release) => release.tag_name === input.tag)
   if (existing) {
-    const sameRunAndCommit = existing.body?.includes(releaseRunMarker(input.runId, triggerCommit))
-    if (!sameRunAndCommit) {
-      throw new Error(`${input.tag} already has a release from another commit or workflow run`)
-    }
+    validatePublishedRelease(existing, input.runId, triggerCommit)
+    return { version, latest: latestStableTag(input.tags, input.releases, input.tag), published: true }
   }
 
   const latest = latestStableTag(input.tags, input.releases, input.tag)
   assertVersionIsNewer(input.tag, latest)
-  return { version, latest }
+  return { version, latest, published: false }
 }
 
 function git(args: string[], allowFailure = false) {
@@ -140,6 +216,20 @@ export function stampReleaseVersion(tag: string, root = path.resolve(import.meta
   return version
 }
 
+export function sealReleaseNotes(notesFile: string, runId: string, commit: string, assetsDirectory: string) {
+  const assetFiles = readdirSync(assetsDirectory)
+    .filter((name) => name.endsWith("-setup.exe") || name.endsWith(".sig") || name === "latest.json")
+    .map((name) => path.join(assetsDirectory, name))
+  expectedReleaseAssetNames(assetFiles.map((file) => ({ name: path.basename(file) })))
+  if (assetFiles.length !== 3) throw new Error("Release notes must be sealed with exactly three release assets")
+
+  const assets = assetFiles.map((file) => ({
+    name: path.basename(file),
+    digest: `sha256:${createHash("sha256").update(readFileSync(file)).digest("hex")}`,
+  }))
+  appendFileSync(notesFile, `\n${releaseRunMarker(runId, commit)}\n${releaseAssetsMarker(assets)}\n`)
+}
+
 async function checkPolicy(tag: string, triggerCommit: string, runId: string) {
   const repository = process.env.GITHUB_REPOSITORY
   const token = process.env.GITHUB_TOKEN
@@ -160,14 +250,15 @@ async function checkPolicy(tag: string, triggerCommit: string, runId: string) {
   })
 
   const output = process.env.GITHUB_OUTPUT
-  if (output) appendFileSync(output, `version=${result.version}\ncommit=${commit}\n`)
-  console.log(`${tag} (${commit}) is eligible; previous stable tag is ${result.latest ?? "none"}`)
+  if (output) appendFileSync(output, `version=${result.version}\ncommit=${commit}\npublished=${result.published}\n`)
+  if (result.published) console.log(`${tag} (${commit}) is already published with verified immutable assets`)
+  else console.log(`${tag} (${commit}) is eligible; previous stable tag is ${result.latest ?? "none"}`)
 }
 
 if (import.meta.main) {
-  const [command, tag, triggerCommit, runId] = process.argv.slice(2)
-  if (!tag) throw new Error("Usage: bun scripts/release-policy.ts <check|stamp> <tag>")
-  if (command === "check") await checkPolicy(tag, triggerCommit, runId)
-  else if (command === "stamp") console.log(`Stamped release version ${stampReleaseVersion(tag)}`)
+  const [command, ...args] = process.argv.slice(2)
+  if (command === "check" && args.length === 3) await checkPolicy(args[0], args[1], args[2])
+  else if (command === "stamp" && args.length === 1) console.log(`Stamped release version ${stampReleaseVersion(args[0])}`)
+  else if (command === "seal" && args.length === 4) sealReleaseNotes(args[0], args[1], args[2], args[3])
   else throw new Error(`Unknown release policy command: ${command}`)
 }

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { createHash } from "node:crypto"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -6,7 +7,9 @@ import {
   assertVersionIsNewer,
   compareStableTags,
   latestStableTag,
+  releaseAssetsMarker,
   releaseRunMarker,
+  sealReleaseNotes,
   stampReleaseVersion,
   validateReleasePolicy,
   versionFromTag,
@@ -87,8 +90,9 @@ test("policy allows no prior release and same-event reruns of the newest tag", (
     containedInMaster: true,
     tags: ["v1.0.0"],
     releases: [],
-  })).toEqual({ version: "1.0.0", latest: undefined })
+  })).toEqual({ version: "1.0.0", latest: undefined, published: false })
 
+  const assets = publishedAssets()
   expect(validateReleasePolicy({
     tag: "v1.2.0",
     triggerCommit: commit,
@@ -98,9 +102,70 @@ test("policy allows no prior release and same-event reruns of the newest tag", (
     tags: ["v1.1.0", "v1.2.0"],
     releases: [{
       tag_name: "v1.2.0",
-      body: releaseRunMarker("100", commit),
+      body: publishedBody("100", commit, assets),
+      assets,
     }],
-  })).toEqual({ version: "1.2.0", latest: "v1.1.0" })
+  })).toEqual({ version: "1.2.0", latest: "v1.1.0", published: true })
+})
+
+function publishedAssets() {
+  return [
+    { name: "Drift_1.2.0_x64-setup.exe", state: "uploaded", size: 10, digest: `sha256:${"a".repeat(64)}` },
+    { name: "Drift_1.2.0_x64-setup.exe.sig", state: "uploaded", size: 10, digest: `sha256:${"b".repeat(64)}` },
+    { name: "latest.json", state: "uploaded", size: 10, digest: `sha256:${"c".repeat(64)}` },
+  ]
+}
+
+function publishedBody(runId: string, commit: string, assets = publishedAssets()) {
+  return [
+    "Release notes",
+    releaseRunMarker(runId, commit),
+    releaseAssetsMarker(assets.map((asset) => ({ name: asset.name, digest: asset.digest }))),
+  ].join("\n")
+}
+
+test("an immutable published rerun is a no-op even after a newer tag exists", () => {
+  const commit = "a".repeat(40)
+  const assets = publishedAssets()
+  expect(validateReleasePolicy({
+    tag: "v1.2.0",
+    triggerCommit: commit,
+    resolvedCommit: commit,
+    runId: "100",
+    containedInMaster: true,
+    tags: ["v1.2.0", "v1.3.0"],
+    releases: [{ tag_name: "v1.2.0", body: publishedBody("100", commit, assets), assets }],
+  })).toEqual({ version: "1.2.0", latest: "v1.3.0", published: true })
+})
+
+test("published reruns reject mismatched markers and assets", () => {
+  const commit = "a".repeat(40)
+  const assets = publishedAssets()
+  const input = {
+    tag: "v1.2.0",
+    triggerCommit: commit,
+    resolvedCommit: commit,
+    runId: "100",
+    containedInMaster: true,
+    tags: ["v1.2.0"],
+  }
+
+  expect(() => validateReleasePolicy({
+    ...input,
+    releases: [{ tag_name: "v1.2.0", body: publishedBody("101", commit, assets), assets }],
+  })).toThrow("another commit or workflow run")
+  expect(() => validateReleasePolicy({
+    ...input,
+    releases: [{
+      tag_name: "v1.2.0",
+      body: publishedBody("100", commit, assets),
+      assets: assets.map((asset, index) => index === 0 ? { ...asset, digest: `sha256:${"d".repeat(64)}` } : asset),
+    }],
+  })).toThrow("does not match its immutable digest")
+  expect(() => validateReleasePolicy({
+    ...input,
+    releases: [{ tag_name: "v1.2.0", body: publishedBody("100", commit, assets), assets: assets.slice(1) }],
+  })).toThrow("exactly one setup executable")
 })
 
 test("policy rejects same-name releases from a moved tag or another event", () => {
@@ -130,6 +195,28 @@ test("policy rejects same-name releases from a moved tag or another event", () =
   })).toThrow("another commit or workflow run")
 })
 
+test("release notes are sealed with exact local asset hashes", () => {
+  const temporary = mkdtempSync(path.join(os.tmpdir(), "drift-release-assets-"))
+  try {
+    const notes = path.join(temporary, "notes.md")
+    writeFileSync(notes, "Notes\n")
+    writeFileSync(path.join(temporary, "Drift_1.2.0_x64-setup.exe"), "installer")
+    writeFileSync(path.join(temporary, "Drift_1.2.0_x64-setup.exe.sig"), "signature")
+    writeFileSync(path.join(temporary, "latest.json"), "manifest")
+    sealReleaseNotes(notes, "100", "A".repeat(40), temporary)
+
+    const sealed = readFileSync(notes, "utf8")
+    expect(sealed).toContain(releaseRunMarker("100", "a".repeat(40)))
+    expect(sealed).toContain(releaseAssetsMarker([
+      { name: "Drift_1.2.0_x64-setup.exe", digest: `sha256:${createHash("sha256").update("installer").digest("hex")}` },
+      { name: "Drift_1.2.0_x64-setup.exe.sig", digest: `sha256:${createHash("sha256").update("signature").digest("hex")}` },
+      { name: "latest.json", digest: `sha256:${createHash("sha256").update("manifest").digest("hex")}` },
+    ]))
+  } finally {
+    rmSync(temporary, { recursive: true, force: true })
+  }
+})
+
 test("release stamping updates every package version and is idempotent", () => {
   const temporary = mkdtempSync(path.join(os.tmpdir(), "drift-release-policy-"))
   try {
@@ -156,6 +243,7 @@ test("release workflow gates secrets and publication on policy and full validati
   const publish = workflow.slice(workflow.indexOf("  publish:"))
 
   expect(workflow).toContain("needs: tag-policy")
+  expect(workflow).toContain("if: needs.tag-policy.outputs.published != 'true'")
   expect(signing).toContain("needs: [tag-policy, validation]")
   expect(publish).toContain("needs: [tag-policy, validation, signed-artifacts]")
   expect(validation).not.toContain("secrets.")
@@ -177,7 +265,8 @@ test("release workflow gates secrets and publication on policy and full validati
   expect(publish).not.toContain("secrets.")
   expect(publish).toContain("uses: actions/download-artifact@")
   expect(publish).toContain("target_commitish: ${{ needs.tag-policy.outputs.commit }}")
-  expect(publish).toContain("another commit or workflow run")
+  expect(publish).toContain("Revalidate complete release policy")
+  expect(workflow).not.toContain("overwrite_files:")
 })
 
 test("release workflow uses immutable action pins and triggering SHA binding", () => {
@@ -187,6 +276,24 @@ test("release workflow uses immutable action pins and triggering SHA binding", (
   expect(actions.length).toBeGreaterThan(0)
   for (const action of actions) expect(action).toMatch(/^[^@]+@[0-9a-f]{40}$/)
   expect(workflow).toContain('check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"')
-  expect(workflow).toContain("$resolved -ne $commit")
-  expect(workflow).toContain("<!-- drift-release: run=${{ github.run_id }} commit=$commit -->")
+  expect(workflow).toContain("bun-version: 1.3.14")
+  expect(workflow).not.toContain("bun-version: latest")
+})
+
+test("release workflow serializes tags globally and rechecks full policy immediately before publication", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
+  const publish = workflow.slice(workflow.indexOf("  publish:"))
+  const finalPolicy = publish.indexOf("bun scripts/release-policy.ts check")
+  const publicationStep = publish.indexOf("- name: Publish stable GitHub release")
+  const publication = publish.indexOf("uses: softprops/action-gh-release@")
+
+  expect(workflow).toContain("group: stable-release")
+  expect(workflow).not.toContain("group: release-${{ github.ref }}")
+  expect(publish).toContain("Fetch current release policy refs")
+  expect(finalPolicy).toBeGreaterThan(0)
+  expect(publicationStep).toBeGreaterThan(finalPolicy)
+  expect(publication).toBeGreaterThan(finalPolicy)
+  expect(publish.slice(finalPolicy, publicationStep)).not.toContain("- name:")
+  expect(publish).toContain("if: steps.final-policy.outputs.published != 'true'")
+  expect(workflow).toContain("release-${{ github.run_id }}-${{ github.run_attempt }}-")
 })

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -18,10 +18,14 @@ import {
 const root = path.resolve(import.meta.dirname, "..")
 
 test("stable tags have exactly one v and three numeric components", () => {
+  expect(versionFromTag("v0.0.0")).toBe("0.0.0")
   expect(versionFromTag("v1.2.3")).toBe("1.2.3")
   for (const tag of [
     "1.2.3",
     "vv1.2.3",
+    "v01.2.3",
+    "v1.02.3",
+    "v1.2.03",
     "v1.2",
     "v1.2.3junk",
     "v1.2.3-beta.1",
@@ -33,6 +37,7 @@ test("stable tags have exactly one v and three numeric components", () => {
 test("stable versions compare numerically", () => {
   expect(compareStableTags("v2.0.0", "v1.999.999")).toBe(1)
   expect(compareStableTags("v1.10.0", "v1.9.99")).toBe(1)
+  expect(compareStableTags("v9007199254740993.0.0", "v9007199254740992.999.999")).toBe(1)
   expect(compareStableTags("v1.2.3", "v1.2.3")).toBe(0)
 })
 

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import {
+  assertVersionIsNewer,
+  compareStableTags,
+  latestStableTag,
+  stampReleaseVersion,
+  validateReleasePolicy,
+  versionFromTag,
+} from "../scripts/release-policy"
+
+const root = path.resolve(import.meta.dirname, "..")
+
+test("stable tags have exactly one v and three numeric components", () => {
+  expect(versionFromTag("v1.2.3")).toBe("1.2.3")
+  for (const tag of [
+    "1.2.3",
+    "vv1.2.3",
+    "v1.2",
+    "v1.2.3junk",
+    "v1.2.3-beta.1",
+    "v1.2.3+build.1",
+    "v1.2.3.4",
+  ]) expect(() => versionFromTag(tag)).toThrow("must match vMAJOR.MINOR.PATCH exactly")
+})
+
+test("stable versions compare numerically", () => {
+  expect(compareStableTags("v2.0.0", "v1.999.999")).toBe(1)
+  expect(compareStableTags("v1.10.0", "v1.9.99")).toBe(1)
+  expect(compareStableTags("v1.2.3", "v1.2.3")).toBe(0)
+})
+
+test("release versions must be strictly newer", () => {
+  expect(() => assertVersionIsNewer("v1.2.2", "v1.2.3")).toThrow("must be newer")
+  expect(() => assertVersionIsNewer("v1.2.3", "v1.2.3")).toThrow("must be newer")
+  expect(() => assertVersionIsNewer("v1.2.4", "v1.2.3")).not.toThrow()
+  expect(() => assertVersionIsNewer("v1.0.0", undefined)).not.toThrow()
+})
+
+test("latest stable candidate excludes prereleases, drafts, malformed tags, and the current rerun", () => {
+  expect(latestStableTag(
+    ["v1.1.0", "v1.2.0", "v9.0.0-beta.1"],
+    [
+      { tag_name: "v1.3.0", prerelease: true },
+      { tag_name: "v1.4.0", draft: true },
+      { tag_name: "v1.2.1junk" },
+      { tag_name: "v1.2.0" },
+    ],
+    "v1.2.0",
+  )).toBe("v1.1.0")
+})
+
+test("policy rejects a tag whose commit is outside origin/master", () => {
+  expect(() => validateReleasePolicy({
+    tag: "v1.2.0",
+    containedInMaster: false,
+    tags: ["v1.1.0"],
+    releases: [],
+  })).toThrow("not contained in origin/master")
+})
+
+test("policy allows no prior release and safe reruns of the newest tag", () => {
+  expect(validateReleasePolicy({
+    tag: "v1.0.0",
+    containedInMaster: true,
+    tags: ["v1.0.0"],
+    releases: [{ tag_name: "v1.0.0" }],
+  })).toEqual({ version: "1.0.0", latest: undefined })
+
+  expect(validateReleasePolicy({
+    tag: "v1.2.0",
+    containedInMaster: true,
+    tags: ["v1.1.0", "v1.2.0"],
+    releases: [{ tag_name: "v1.2.0" }],
+  })).toEqual({ version: "1.2.0", latest: "v1.1.0" })
+})
+
+test("release stamping updates every package version and is idempotent", () => {
+  const temporary = mkdtempSync(path.join(os.tmpdir(), "drift-release-policy-"))
+  try {
+    mkdirSync(path.join(temporary, "src-tauri"))
+    writeFileSync(path.join(temporary, "package.json"), '{"version":"1.0.0"}\n')
+    writeFileSync(path.join(temporary, "src-tauri/tauri.conf.json"), '{"version":"1.0.0"}\n')
+    writeFileSync(path.join(temporary, "src-tauri/Cargo.toml"), '[package]\nname = "drift"\nversion = "1.0.0"\n')
+    writeFileSync(path.join(temporary, "src-tauri/Cargo.lock"), '[[package]]\nname = "drift"\nversion = "1.0.0"\n')
+
+    expect(stampReleaseVersion("v2.3.4", temporary)).toBe("2.3.4")
+    expect(stampReleaseVersion("v2.3.4", temporary)).toBe("2.3.4")
+    for (const relative of ["package.json", "src-tauri/tauri.conf.json", "src-tauri/Cargo.toml", "src-tauri/Cargo.lock"]) {
+      expect(readFileSync(path.join(temporary, relative), "utf8")).toContain("2.3.4")
+    }
+  } finally {
+    rmSync(temporary, { recursive: true, force: true })
+  }
+})
+
+test("release workflow gates secrets and publication on policy and full validation", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
+  const validation = workflow.slice(workflow.indexOf("  validation:"), workflow.indexOf("  publish:"))
+  const publish = workflow.slice(workflow.indexOf("  publish:"))
+
+  expect(workflow).toContain("needs: tag-policy")
+  expect(publish).toContain("needs: [tag-policy, validation]")
+  expect(validation).not.toContain("secrets.")
+  for (const command of [
+    "bun install --frozen-lockfile",
+    "bun run typecheck",
+    "bun run test",
+    "bun run test:engine",
+    "bun run build:engine",
+    "cargo test --locked --manifest-path src-tauri/Cargo.toml",
+    "bun run build:native",
+  ]) expect(validation).toContain(command)
+  expect(publish).toContain("TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}")
+  expect(publish).toContain("uses: softprops/action-gh-release@v2")
+})

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -6,6 +6,7 @@ import {
   assertVersionIsNewer,
   compareStableTags,
   latestStableTag,
+  releaseRunMarker,
   stampReleaseVersion,
   validateReleasePolicy,
   versionFromTag,
@@ -55,26 +56,78 @@ test("latest stable candidate excludes prereleases, drafts, malformed tags, and 
 test("policy rejects a tag whose commit is outside origin/master", () => {
   expect(() => validateReleasePolicy({
     tag: "v1.2.0",
+    triggerCommit: "a".repeat(40),
+    resolvedCommit: "a".repeat(40),
+    runId: "100",
     containedInMaster: false,
     tags: ["v1.1.0"],
     releases: [],
   })).toThrow("not contained in origin/master")
 })
 
-test("policy allows no prior release and safe reruns of the newest tag", () => {
+test("policy binds the resolved tag to the triggering commit", () => {
+  expect(() => validateReleasePolicy({
+    tag: "v1.2.0",
+    triggerCommit: "a".repeat(40),
+    resolvedCommit: "b".repeat(40),
+    runId: "100",
+    containedInMaster: true,
+    tags: ["v1.2.0"],
+    releases: [],
+  })).toThrow("not triggering commit")
+})
+
+test("policy allows no prior release and same-event reruns of the newest tag", () => {
+  const commit = "a".repeat(40)
   expect(validateReleasePolicy({
     tag: "v1.0.0",
+    triggerCommit: commit,
+    resolvedCommit: commit,
+    runId: "100",
     containedInMaster: true,
     tags: ["v1.0.0"],
-    releases: [{ tag_name: "v1.0.0" }],
+    releases: [],
   })).toEqual({ version: "1.0.0", latest: undefined })
 
   expect(validateReleasePolicy({
     tag: "v1.2.0",
+    triggerCommit: commit,
+    resolvedCommit: commit,
+    runId: "100",
     containedInMaster: true,
     tags: ["v1.1.0", "v1.2.0"],
-    releases: [{ tag_name: "v1.2.0" }],
+    releases: [{
+      tag_name: "v1.2.0",
+      body: releaseRunMarker("100", commit),
+    }],
   })).toEqual({ version: "1.2.0", latest: "v1.1.0" })
+})
+
+test("policy rejects same-name releases from a moved tag or another event", () => {
+  const commit = "a".repeat(40)
+  const input = {
+    tag: "v1.2.0",
+    triggerCommit: commit,
+    resolvedCommit: commit,
+    runId: "100",
+    containedInMaster: true,
+    tags: ["v1.1.0", "v1.2.0"],
+  }
+
+  expect(() => validateReleasePolicy({
+    ...input,
+    releases: [{
+      tag_name: "v1.2.0",
+      body: releaseRunMarker("100", "b".repeat(40)),
+    }],
+  })).toThrow("another commit or workflow run")
+  expect(() => validateReleasePolicy({
+    ...input,
+    releases: [{
+      tag_name: "v1.2.0",
+      body: releaseRunMarker("101", commit),
+    }],
+  })).toThrow("another commit or workflow run")
 })
 
 test("release stamping updates every package version and is idempotent", () => {
@@ -98,11 +151,13 @@ test("release stamping updates every package version and is idempotent", () => {
 
 test("release workflow gates secrets and publication on policy and full validation", () => {
   const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
-  const validation = workflow.slice(workflow.indexOf("  validation:"), workflow.indexOf("  publish:"))
+  const validation = workflow.slice(workflow.indexOf("  validation:"), workflow.indexOf("  signed-artifacts:"))
+  const signing = workflow.slice(workflow.indexOf("  signed-artifacts:"), workflow.indexOf("  publish:"))
   const publish = workflow.slice(workflow.indexOf("  publish:"))
 
   expect(workflow).toContain("needs: tag-policy")
-  expect(publish).toContain("needs: [tag-policy, validation]")
+  expect(signing).toContain("needs: [tag-policy, validation]")
+  expect(publish).toContain("needs: [tag-policy, validation, signed-artifacts]")
   expect(validation).not.toContain("secrets.")
   for (const command of [
     "bun install --frozen-lockfile",
@@ -113,6 +168,25 @@ test("release workflow gates secrets and publication on policy and full validati
     "cargo test --locked --manifest-path src-tauri/Cargo.toml",
     "bun run build:native",
   ]) expect(validation).toContain(command)
-  expect(publish).toContain("TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}")
-  expect(publish).toContain("uses: softprops/action-gh-release@v2")
+  expect(signing).toContain("contents: read")
+  expect(signing).not.toContain("contents: write")
+  expect(signing).toContain("persist-credentials: false")
+  expect(signing).toContain("TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}")
+  expect(signing).toContain("uses: actions/upload-artifact@")
+  expect(publish).toContain("contents: write")
+  expect(publish).not.toContain("secrets.")
+  expect(publish).toContain("uses: actions/download-artifact@")
+  expect(publish).toContain("target_commitish: ${{ needs.tag-policy.outputs.commit }}")
+  expect(publish).toContain("another commit or workflow run")
+})
+
+test("release workflow uses immutable action pins and triggering SHA binding", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
+  const actions = [...workflow.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map((match) => match[1])
+
+  expect(actions.length).toBeGreaterThan(0)
+  for (const action of actions) expect(action).toMatch(/^[^@]+@[0-9a-f]{40}$/)
+  expect(workflow).toContain('check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"')
+  expect(workflow).toContain("$resolved -ne $commit")
+  expect(workflow).toContain("<!-- drift-release: run=${{ github.run_id }} commit=$commit -->")
 })


### PR DESCRIPTION
## Summary

- enforce an exact stable-only tag policy, master ancestry, and monotonic versions across Git tags and stable GitHub releases
- require a secret-free full validation job for the resolved tag commit before signing or publication
- make stable release reruns idempotent and add policy, stamping, and workflow dependency regressions
- document the hardened maintainer release procedure

Fixes #11
Fixes #16

## Validation

- `bun install --frozen-lockfile`
- `bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream`
- `bun install --frozen-lockfile --cwd engine/opencode`
- `bun run test:release-policy` (8 passed)
- `bun run typecheck`
- `bun run test` (126 passed)
- `bun run build`
- `bun run test:engine`
- `bun run build:engine` (engine smoke test passed)
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` (17 passed)
- `bun run build:native`
- live policy check for `v1.1.2` against GitHub releases, repository tags, and `origin/master`
- `git diff --check origin/master...HEAD`

`actionlint` was unavailable locally; Docker was installed but its daemon was not running. Workflow dependency and secret-boundary assertions are covered by `tests/release-policy.test.ts`.
