### PR TITLE
Fail engine commands on incomplete overlay restoration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ examples/
 .tauri.log
 .tauri/
 engine/.overlay-lock-reclaimed/
+engine/.overlay-lock-candidate-*/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/
 .vite.log
 .tauri.log
 .tauri/
+engine/.overlay-lock-reclaimed/

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -18,11 +18,13 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
   the subtree. Build and engine-test commands apply them under a process lock and reverse
   every applied patch after the command, including recovery after an interrupted prior
   command. Restoration failures fail the command, preserve callback and cleanup errors,
-  and retain `engine/.overlay-lock` until a later run proves the subtree is pristine. On
-  startup, only a fully applied patch is recovered automatically; an indeterminate patch
-  state fails with a manual-recovery error instead of being silently skipped. A patch that
-  no longer applies fails with an explicit refresh message instead of creating a subtree
-  merge conflict.
+  and retain `engine/.overlay-lock` until a later run proves the subtree is pristine. Dead
+  lock generations are atomically moved to ignored UUID tombstones before a new owner can
+  claim the lock; retaining those tombstones prevents delayed stale contenders from moving
+  a newer live lock. On startup, only a fully applied patch is recovered automatically; an
+  indeterminate patch state fails with a manual-recovery error instead of being silently
+  skipped. A patch that no longer applies fails with an explicit refresh message instead of
+  creating a subtree merge conflict.
 - Dev: `bun run dev` creates an ephemeral fail-closed MCP policy, spawns
   `drift-engine.exe serve --hostname 127.0.0.1 --port 4096` (cwd = repo root), and
   gives the engine and Vite a random shared password.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -18,10 +18,13 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
   the subtree. Build and engine-test commands apply them under a process lock and reverse
   every applied patch after the command, including recovery after an interrupted prior
   command. Restoration failures fail the command, preserve callback and cleanup errors,
-  and retain `engine/.overlay-lock` until a later run proves the subtree is pristine. Dead
-  lock generations are atomically moved to ignored UUID tombstones before a new owner can
-  claim the lock; retaining those tombstones prevents delayed stale contenders from moving
-  a newer live lock. On startup, only a fully applied patch is recovered automatically; an
+  and retain `engine/.overlay-lock` until a later run proves the subtree is pristine. Lock
+  ownership is initialized in an ignored same-volume candidate and atomically published
+  without replacement. Dead generations are atomically moved to UUID tombstones before a new
+  owner can claim the lock; retaining those tombstones prevents delayed stale contenders from
+  moving a newer live lock. An empty legacy ownerless lock is quarantined only after the
+  upstream subtree is proven clean; dirty or malformed ownerless locks fail closed. On startup,
+  only a fully applied patch is recovered automatically; an
   indeterminate patch state fails with a manual-recovery error instead of being silently
   skipped. A patch that no longer applies fails with an explicit refresh message instead of
   creating a subtree merge conflict.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -16,7 +16,11 @@ servers, plugins, providers) applies unchanged. Users do not install opencode.
   of their code; their build script is the contract.
 - Drift-specific engine adaptations live as named patches in `engine/overlays`, outside
   the subtree. Build and engine-test commands apply them under a process lock and reverse
-  them in `finally`, including recovery after an interrupted prior command. A patch that
+  every applied patch after the command, including recovery after an interrupted prior
+  command. Restoration failures fail the command, preserve callback and cleanup errors,
+  and retain `engine/.overlay-lock` until a later run proves the subtree is pristine. On
+  startup, only a fully applied patch is recovered automatically; an indeterminate patch
+  state fails with a manual-recovery error instead of being silently skipped. A patch that
   no longer applies fails with an explicit refresh message instead of creating a subtree
   merge conflict.
 - Dev: `bun run dev` creates an ephemeral fail-closed MCP policy, spawns

--- a/scripts/engine-overlays.ts
+++ b/scripts/engine-overlays.ts
@@ -44,9 +44,38 @@ async function gitApply(args: string[], quiet = false) {
   return (await process.exited) === 0
 }
 
+// The shipped format was a directory holding only the owner's decimal pid, which also names its generation.
+function readLegacyLockOwner(directory: string): LockOwner | undefined {
+  let entries: string[]
+  try {
+    entries = readdirSync(directory)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOTDIR") return undefined
+    throw error
+  }
+  if (entries.length !== 1 || entries[0] !== "pid") return undefined
+
+  const raw = readFileSync(path.join(directory, "pid"), "utf8").trim()
+  const pid = Number(raw)
+  if (!/^[1-9][0-9]*$/.test(raw) || !Number.isSafeInteger(pid)) {
+    throw new Error(`Invalid engine overlay lock owner; inspect ${directory} before retrying`)
+  }
+  return { pid, token: `legacy-pid-${pid}` }
+}
+
 function readLockOwner(directory: string): LockOwner {
-  const ownerFile = statSync(directory).isDirectory() ? path.join(directory, "owner.json") : directory
-  const raw = readFileSync(ownerFile, "utf8")
+  const isDirectory = statSync(directory).isDirectory()
+  const ownerFile = isDirectory ? path.join(directory, "owner.json") : directory
+  let raw: string
+  try {
+    raw = readFileSync(ownerFile, "utf8")
+  } catch (error) {
+    if (!isDirectory || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    const legacy = readLegacyLockOwner(directory)
+    // Only the exact legacy shape is recognized; everything else stays ownerless and fails closed.
+    if (!legacy) throw error
+    return legacy
+  }
   let value: unknown
   try {
     value = JSON.parse(raw)

--- a/scripts/engine-overlays.ts
+++ b/scripts/engine-overlays.ts
@@ -1,5 +1,15 @@
 import { randomUUID } from "node:crypto"
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
 import path from "node:path"
 
 const root = path.resolve(import.meta.dirname, "..")
@@ -11,6 +21,12 @@ const ownedLocks = new Map<string, string>()
 interface LockOwner {
   pid: number
   token: string
+}
+
+export interface EngineOverlayLockOptions {
+  beforeOwnerWrite?: (candidate: string) => void
+  beforePublish?: (candidate: string) => void
+  upstreamChanges?: () => Promise<string[]>
 }
 
 const overlays = () =>
@@ -29,7 +45,8 @@ async function gitApply(args: string[], quiet = false) {
 }
 
 function readLockOwner(directory: string): LockOwner {
-  const raw = readFileSync(path.join(directory, "owner.json"), "utf8")
+  const ownerFile = statSync(directory).isDirectory() ? path.join(directory, "owner.json") : directory
+  const raw = readFileSync(ownerFile, "utf8")
   let value: unknown
   try {
     value = JSON.parse(raw)
@@ -51,62 +68,124 @@ function readLockOwner(directory: string): LockOwner {
   return value as LockOwner
 }
 
-export async function acquireEngineOverlayLock(directory = lockDirectory) {
-  let missingOwnerAttempts = 0
-  for (let attempt = 0; attempt < 240; attempt++) {
-    let acquired = false
-    try {
-      mkdirSync(directory)
-      acquired = true
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
-    }
-    if (acquired) {
-      const token = randomUUID()
-      writeFileSync(path.join(directory, "owner.json"), JSON.stringify({ pid: process.pid, token }), { flag: "wx" })
-      ownedLocks.set(directory, token)
-      return
-    }
+function contention(error: unknown, destination: string) {
+  const code = (error as NodeJS.ErrnoException).code
+  if (code === "EEXIST" || code === "ENOTEMPTY") return true
+  return (code === "EPERM" || code === "EACCES" || code === "EISDIR" || code === "ENOTDIR") && existsSync(destination)
+}
 
-    let owner: LockOwner
-    try {
-      owner = readLockOwner(directory)
-    } catch (ownerError) {
-      if ((ownerError as NodeJS.ErrnoException).code === "ENOENT" && missingOwnerAttempts++ < 3) {
-        await Bun.sleep(250)
-        continue
-      }
-      throw ownerError
-    }
-    missingOwnerAttempts = 0
-    try {
-      process.kill(owner.pid, 0)
-    } catch (ownerError) {
-      const code = (ownerError as NodeJS.ErrnoException).code
-      if (code === "EPERM") {
-        await Bun.sleep(250)
-        continue
-      }
-      if (code !== "ESRCH") throw ownerError
-
-      const reclaimedDirectory = `${directory}-reclaimed`
-      mkdirSync(reclaimedDirectory, { recursive: true })
-      const reclaimedLock = path.join(reclaimedDirectory, owner.token)
-      try {
-        // Keeping this generation's destination prevents delayed contenders from moving a newer lock (ABA).
-        renameSync(directory, reclaimedLock)
-      } catch (reclaimError) {
-        const reclaimCode = (reclaimError as NodeJS.ErrnoException).code
-        if (reclaimCode === "ENOENT" || reclaimCode === "EEXIST" || reclaimCode === "ENOTEMPTY") continue
-        if ((reclaimCode === "EPERM" || reclaimCode === "EACCES") && existsSync(reclaimedLock)) continue
-        throw reclaimError
-      }
-      console.warn(`Recovering engine overlays left by process ${owner.pid}`)
-      continue
-    }
-    await Bun.sleep(250)
+function quarantine(directory: string, destination: string) {
+  try {
+    renameSync(directory, destination)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT" || contention(error, destination)) return false
+    throw error
   }
-  throw new Error("Timed out waiting for the engine overlay lock")
+}
+
+async function quarantineOwnerlessLock(directory: string, options: EngineOverlayLockOptions) {
+  let entries: string[]
+  try {
+    entries = readdirSync(directory)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOTDIR") return false
+    throw error
+  }
+  if (entries.length > 0) {
+    throw new Error(`Ownerless engine overlay lock contains unexpected files; inspect ${directory} before retrying`)
+  }
+
+  let changes: string[]
+  try {
+    changes = await (options.upstreamChanges ?? upstreamChanges)()
+  } catch (cause) {
+    throw new Error(`Could not verify whether ownerless engine overlay lock ${directory} is safe to recover`, { cause })
+  }
+  if (changes.length > 0) {
+    throw new Error(
+      `Ownerless engine overlay lock cannot be recovered while engine/upstream is dirty; inspect ${directory} before retrying:\n${changes.join("\n")}`,
+    )
+  }
+
+  const reclaimedDirectory = `${directory}-reclaimed`
+  mkdirSync(reclaimedDirectory, { recursive: true })
+  // One retained destination makes delayed legacy contenders fail instead of moving a newer lock (ABA).
+  if (!quarantine(directory, path.join(reclaimedDirectory, "ownerless-legacy"))) return false
+  console.warn("Recovering ownerless engine overlay lock after verifying engine/upstream is clean")
+  return true
+}
+
+export async function acquireEngineOverlayLock(
+  directory = lockDirectory,
+  options: EngineOverlayLockOptions = {},
+) {
+  const token = randomUUID()
+  const candidate = `${directory}-candidate-${token}`
+  const candidateOwner = path.join(candidate, "owner.json")
+  mkdirSync(candidate)
+
+  let published = false
+  let missingOwnerAttempts = 0
+  try {
+    options.beforeOwnerWrite?.(candidate)
+    writeFileSync(candidateOwner, JSON.stringify({ pid: process.pid, token }), { flag: "wx" })
+    options.beforePublish?.(candidate)
+
+    for (let attempt = 0; attempt < 240; attempt++) {
+      try {
+        // A same-volume hard link atomically publishes complete metadata and never replaces an existing lock.
+        linkSync(candidateOwner, directory)
+        published = true
+        ownedLocks.set(directory, token)
+        return
+      } catch (error) {
+        if (!contention(error, directory)) throw error
+      }
+
+      let owner: LockOwner
+      try {
+        owner = readLockOwner(directory)
+      } catch (ownerError) {
+        if ((ownerError as NodeJS.ErrnoException).code !== "ENOENT") throw ownerError
+        if (!existsSync(directory)) continue
+        if (missingOwnerAttempts++ < 3) {
+          await Bun.sleep(250)
+          continue
+        }
+        if (await quarantineOwnerlessLock(directory, options)) missingOwnerAttempts = 0
+        continue
+      }
+      missingOwnerAttempts = 0
+      try {
+        process.kill(owner.pid, 0)
+      } catch (ownerError) {
+        const code = (ownerError as NodeJS.ErrnoException).code
+        if (code === "EPERM") {
+          await Bun.sleep(250)
+          continue
+        }
+        if (code !== "ESRCH") throw ownerError
+
+        const reclaimedDirectory = `${directory}-reclaimed`
+        mkdirSync(reclaimedDirectory, { recursive: true })
+        const reclaimedLock = path.join(reclaimedDirectory, owner.token)
+        // Keeping this generation's destination prevents delayed contenders from moving a newer lock (ABA).
+        if (!quarantine(directory, reclaimedLock)) continue
+        console.warn(`Recovering engine overlays left by process ${owner.pid}`)
+        continue
+      }
+      await Bun.sleep(250)
+    }
+    throw new Error("Timed out waiting for the engine overlay lock")
+  } finally {
+    try {
+      rmSync(candidate, { recursive: true, force: true })
+    } catch (error) {
+      if (!published) throw error
+      console.warn(`Could not remove published engine overlay lock candidate ${candidate}`)
+    }
+  }
 }
 
 export function releaseEngineOverlayLock(directory = lockDirectory) {

--- a/scripts/engine-overlays.ts
+++ b/scripts/engine-overlays.ts
@@ -22,6 +22,7 @@ async function gitApply(args: string[], quiet = false) {
 }
 
 async function acquireLock() {
+  let missingOwnerAttempts = 0
   for (let attempt = 0; attempt < 240; attempt++) {
     try {
       mkdirSync(lockDirectory)
@@ -29,12 +30,32 @@ async function acquireLock() {
       return
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
+      let owner = 0
       try {
-        const owner = Number(readFileSync(path.join(lockDirectory, "pid"), "utf8"))
+        owner = Number(readFileSync(path.join(lockDirectory, "pid"), "utf8"))
+      } catch (ownerError) {
+        if ((ownerError as NodeJS.ErrnoException).code !== "ENOENT") throw ownerError
+      }
+      if (!Number.isInteger(owner) || owner <= 0) {
+        if (missingOwnerAttempts++ < 3) {
+          await Bun.sleep(250)
+          continue
+        }
+        throw new Error(`Invalid engine overlay lock owner; inspect ${lockDirectory} before retrying`)
+      }
+      missingOwnerAttempts = 0
+      try {
         process.kill(owner, 0)
-      } catch {
-        rmSync(lockDirectory, { recursive: true, force: true })
-        continue
+      } catch (ownerError) {
+        const code = (ownerError as NodeJS.ErrnoException).code
+        if (code === "EPERM") {
+          await Bun.sleep(250)
+          continue
+        }
+        if (code !== "ESRCH") throw ownerError
+        console.warn(`Recovering engine overlays left by process ${owner}`)
+        writeFileSync(path.join(lockDirectory, "pid"), `${process.pid}`)
+        return
       }
       await Bun.sleep(250)
     }
@@ -42,31 +63,157 @@ async function acquireLock() {
   throw new Error("Timed out waiting for the engine overlay lock")
 }
 
-async function restoreAppliedOverlays() {
-  for (const overlay of overlays().reverse()) {
-    if (await gitApply(["--reverse", "--check", overlay], true)) {
-      if (!(await gitApply(["--reverse", overlay]))) throw new Error(`Could not restore ${path.basename(overlay)}`)
+function releaseLock() {
+  const owner = Number(readFileSync(path.join(lockDirectory, "pid"), "utf8"))
+  if (owner !== process.pid) throw new Error(`Engine overlay lock is owned by process ${owner}`)
+  rmSync(lockDirectory, { recursive: true })
+}
+
+async function upstreamChanges() {
+  const child = Bun.spawn(["git", "status", "--porcelain=v1", "--untracked-files=all", "--", "engine/upstream"], {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+  const output = await new Response(child.stdout).text()
+  if ((await child.exited) !== 0) throw new Error("Could not inspect the engine upstream worktree")
+  return output.split(/\r?\n/).filter(Boolean)
+}
+
+export interface EngineOverlayOperations {
+  overlays: string[]
+  acquireLock: () => Promise<void>
+  releaseLock: () => void
+  canApply: (overlay: string, reverse: boolean) => Promise<boolean>
+  apply: (overlay: string, reverse: boolean) => Promise<boolean>
+  upstreamChanges: () => Promise<string[]>
+}
+
+function aggregate(errors: unknown[], message: string) {
+  if (errors.length === 1 && errors[0] instanceof Error) return errors[0]
+  return new AggregateError(errors, message)
+}
+
+async function inspectClean(operations: EngineOverlayOperations) {
+  const failures: Error[] = []
+  try {
+    const changes = await operations.upstreamChanges()
+    if (changes.length > 0) {
+      failures.push(new Error(`Engine upstream is not clean after overlay restoration:\n${changes.join("\n")}`))
+    }
+  } catch (cause) {
+    failures.push(new Error("Could not verify the engine upstream worktree is clean", { cause }))
+  }
+  return failures
+}
+
+async function recoverInterruptedOverlays(operations: EngineOverlayOperations) {
+  const failures: Error[] = []
+  let changes: string[]
+  try {
+    changes = await operations.upstreamChanges()
+  } catch (cause) {
+    throw new Error("Could not inspect the engine upstream worktree during startup recovery", { cause })
+  }
+  if (changes.length === 0) return
+
+  for (const overlay of [...operations.overlays].reverse()) {
+    let applied = false
+    try {
+      applied = await operations.canApply(overlay, true)
+    } catch (cause) {
+      failures.push(new Error(`Could not inspect applied ${path.basename(overlay)} during startup recovery`, { cause }))
+      continue
+    }
+    if (!applied) continue
+    try {
+      if (!(await operations.apply(overlay, true))) {
+        failures.push(new Error(`Could not recover ${path.basename(overlay)} from an interrupted command`))
+      }
+    } catch (cause) {
+      failures.push(new Error(`Could not recover ${path.basename(overlay)} from an interrupted command`, { cause }))
     }
   }
+
+  try {
+    changes = await operations.upstreamChanges()
+    if (changes.length > 0) {
+      failures.push(
+        new Error(`Startup recovery left engine/upstream dirty; manual recovery is required:\n${changes.join("\n")}`),
+      )
+    }
+  } catch (cause) {
+    failures.push(new Error("Could not verify startup recovery restored the engine upstream worktree", { cause }))
+  }
+  if (failures.length > 0) throw aggregate(failures, "Engine overlay startup recovery failed")
+}
+
+const defaultOperations = (): EngineOverlayOperations => ({
+  overlays: overlays(),
+  acquireLock,
+  releaseLock,
+  canApply: (overlay, reverse) =>
+    gitApply(reverse ? ["--reverse", "--check", overlay] : ["--check", overlay], true),
+  apply: (overlay, reverse) => gitApply(reverse ? ["--reverse", overlay] : [overlay]),
+  upstreamChanges,
+})
+
+export async function runWithEngineOverlays<T>(run: () => Promise<T>, operations: EngineOverlayOperations) {
+  await operations.acquireLock()
+  const applied: string[] = []
+  let result: T | undefined
+  let operationError: unknown
+  let operationFailed = false
+
+  try {
+    await recoverInterruptedOverlays(operations)
+    for (const overlay of operations.overlays) {
+      if (!(await operations.canApply(overlay, false))) {
+        throw new Error(`${path.basename(overlay)} no longer applies; refresh it for the new OpenCode version`)
+      }
+      if (!(await operations.apply(overlay, false))) throw new Error(`Could not apply ${path.basename(overlay)}`)
+      applied.push(overlay)
+    }
+    result = await run()
+  } catch (error) {
+    operationFailed = true
+    operationError = error
+  }
+
+  const cleanupFailures: Error[] = []
+  for (const overlay of [...applied].reverse()) {
+    try {
+      if (!(await operations.apply(overlay, true))) {
+        cleanupFailures.push(new Error(`Failed to restore ${path.basename(overlay)}`))
+      }
+    } catch (cause) {
+      cleanupFailures.push(new Error(`Failed to restore ${path.basename(overlay)}`, { cause }))
+    }
+  }
+
+  const cleanlinessFailures = await inspectClean(operations)
+  cleanupFailures.push(...cleanlinessFailures)
+  if (cleanlinessFailures.length === 0) {
+    try {
+      operations.releaseLock()
+    } catch (cause) {
+      cleanupFailures.push(new Error("Failed to release the engine overlay lock", { cause }))
+    }
+  }
+
+  const cleanupError =
+    cleanupFailures.length > 0 ? aggregate(cleanupFailures, "Engine overlay restoration failed") : undefined
+  if (operationFailed && cleanupError) {
+    throw new AggregateError(
+      [operationError, cleanupError],
+      "Engine command failed and the upstream subtree was not fully restored",
+    )
+  }
+  if (operationFailed) throw operationError
+  if (cleanupError) throw cleanupError
+  return result as T
 }
 
 export async function withEngineOverlays<T>(run: () => Promise<T>) {
-  await acquireLock()
-  const applied: string[] = []
-  try {
-    await restoreAppliedOverlays()
-    for (const overlay of overlays()) {
-      if (!(await gitApply(["--check", overlay], true))) {
-        throw new Error(`${path.basename(overlay)} no longer applies; refresh it for the new OpenCode version`)
-      }
-      if (!(await gitApply([overlay]))) throw new Error(`Could not apply ${path.basename(overlay)}`)
-      applied.push(overlay)
-    }
-    return await run()
-  } finally {
-    for (const overlay of applied.reverse()) {
-      if (!(await gitApply(["--reverse", overlay]))) console.error(`Failed to restore ${path.basename(overlay)}`)
-    }
-    rmSync(lockDirectory, { recursive: true, force: true })
-  }
+  return runWithEngineOverlays(run, defaultOperations())
 }

--- a/scripts/engine-overlays.ts
+++ b/scripts/engine-overlays.ts
@@ -1,10 +1,17 @@
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { randomUUID } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import path from "node:path"
 
 const root = path.resolve(import.meta.dirname, "..")
 export const engineUpstream = path.join(root, "engine", "upstream")
 const overlayDirectory = path.join(root, "engine", "overlays")
 const lockDirectory = path.join(root, "engine", ".overlay-lock")
+const ownedLocks = new Map<string, string>()
+
+interface LockOwner {
+  pid: number
+  token: string
+}
 
 const overlays = () =>
   readdirSync(overlayDirectory)
@@ -21,52 +28,95 @@ async function gitApply(args: string[], quiet = false) {
   return (await process.exited) === 0
 }
 
-async function acquireLock() {
+function readLockOwner(directory: string): LockOwner {
+  const raw = readFileSync(path.join(directory, "owner.json"), "utf8")
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch (cause) {
+    throw new Error(`Invalid engine overlay lock owner; inspect ${directory} before retrying`, { cause })
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("pid" in value) ||
+    !Number.isInteger(value.pid) ||
+    value.pid <= 0 ||
+    !("token" in value) ||
+    typeof value.token !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.token)
+  ) {
+    throw new Error(`Invalid engine overlay lock owner; inspect ${directory} before retrying`)
+  }
+  return value as LockOwner
+}
+
+export async function acquireEngineOverlayLock(directory = lockDirectory) {
   let missingOwnerAttempts = 0
   for (let attempt = 0; attempt < 240; attempt++) {
+    let acquired = false
     try {
-      mkdirSync(lockDirectory)
-      writeFileSync(path.join(lockDirectory, "pid"), `${process.pid}`)
-      return
+      mkdirSync(directory)
+      acquired = true
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
-      let owner = 0
-      try {
-        owner = Number(readFileSync(path.join(lockDirectory, "pid"), "utf8"))
-      } catch (ownerError) {
-        if ((ownerError as NodeJS.ErrnoException).code !== "ENOENT") throw ownerError
-      }
-      if (!Number.isInteger(owner) || owner <= 0) {
-        if (missingOwnerAttempts++ < 3) {
-          await Bun.sleep(250)
-          continue
-        }
-        throw new Error(`Invalid engine overlay lock owner; inspect ${lockDirectory} before retrying`)
-      }
-      missingOwnerAttempts = 0
-      try {
-        process.kill(owner, 0)
-      } catch (ownerError) {
-        const code = (ownerError as NodeJS.ErrnoException).code
-        if (code === "EPERM") {
-          await Bun.sleep(250)
-          continue
-        }
-        if (code !== "ESRCH") throw ownerError
-        console.warn(`Recovering engine overlays left by process ${owner}`)
-        writeFileSync(path.join(lockDirectory, "pid"), `${process.pid}`)
-        return
-      }
-      await Bun.sleep(250)
     }
+    if (acquired) {
+      const token = randomUUID()
+      writeFileSync(path.join(directory, "owner.json"), JSON.stringify({ pid: process.pid, token }), { flag: "wx" })
+      ownedLocks.set(directory, token)
+      return
+    }
+
+    let owner: LockOwner
+    try {
+      owner = readLockOwner(directory)
+    } catch (ownerError) {
+      if ((ownerError as NodeJS.ErrnoException).code === "ENOENT" && missingOwnerAttempts++ < 3) {
+        await Bun.sleep(250)
+        continue
+      }
+      throw ownerError
+    }
+    missingOwnerAttempts = 0
+    try {
+      process.kill(owner.pid, 0)
+    } catch (ownerError) {
+      const code = (ownerError as NodeJS.ErrnoException).code
+      if (code === "EPERM") {
+        await Bun.sleep(250)
+        continue
+      }
+      if (code !== "ESRCH") throw ownerError
+
+      const reclaimedDirectory = `${directory}-reclaimed`
+      mkdirSync(reclaimedDirectory, { recursive: true })
+      const reclaimedLock = path.join(reclaimedDirectory, owner.token)
+      try {
+        // Keeping this generation's destination prevents delayed contenders from moving a newer lock (ABA).
+        renameSync(directory, reclaimedLock)
+      } catch (reclaimError) {
+        const reclaimCode = (reclaimError as NodeJS.ErrnoException).code
+        if (reclaimCode === "ENOENT" || reclaimCode === "EEXIST" || reclaimCode === "ENOTEMPTY") continue
+        if ((reclaimCode === "EPERM" || reclaimCode === "EACCES") && existsSync(reclaimedLock)) continue
+        throw reclaimError
+      }
+      console.warn(`Recovering engine overlays left by process ${owner.pid}`)
+      continue
+    }
+    await Bun.sleep(250)
   }
   throw new Error("Timed out waiting for the engine overlay lock")
 }
 
-function releaseLock() {
-  const owner = Number(readFileSync(path.join(lockDirectory, "pid"), "utf8"))
-  if (owner !== process.pid) throw new Error(`Engine overlay lock is owned by process ${owner}`)
-  rmSync(lockDirectory, { recursive: true })
+export function releaseEngineOverlayLock(directory = lockDirectory) {
+  const token = ownedLocks.get(directory)
+  const owner = readLockOwner(directory)
+  if (owner.pid !== process.pid || owner.token !== token) {
+    throw new Error(`Engine overlay lock is owned by process ${owner.pid}`)
+  }
+  rmSync(directory, { recursive: true })
+  ownedLocks.delete(directory)
 }
 
 async function upstreamChanges() {
@@ -150,8 +200,8 @@ async function recoverInterruptedOverlays(operations: EngineOverlayOperations) {
 
 const defaultOperations = (): EngineOverlayOperations => ({
   overlays: overlays(),
-  acquireLock,
-  releaseLock,
+  acquireLock: acquireEngineOverlayLock,
+  releaseLock: releaseEngineOverlayLock,
   canApply: (overlay, reverse) =>
     gitApply(reverse ? ["--reverse", "--check", overlay] : ["--check", overlay], true),
   apply: (overlay, reverse) => gitApply(reverse ? ["--reverse", overlay] : [overlay]),

--- a/tests/engine-overlays.test.ts
+++ b/tests/engine-overlays.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { spawn } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import {
@@ -39,6 +39,11 @@ function assertRunning(child: ReturnType<typeof worker>) {
   throw new Error(Buffer.concat(workerErrors.get(child) ?? []).toString() || `Lock worker exited ${child.exitCode}`)
 }
 
+async function waitForExit(child: ReturnType<typeof worker>) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  await new Promise<void>((resolve) => child.once("close", () => resolve()))
+}
+
 async function stop(child: ReturnType<typeof worker>) {
   if (child.exitCode !== null || child.signalCode !== null) return
   const closed = new Promise<void>((resolve) => child.once("close", () => resolve()))
@@ -58,6 +63,10 @@ function acquired(file: string) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
     throw error
   }
+}
+
+function candidates(directory: string) {
+  return readdirSync(directory).filter((entry) => entry.startsWith("lock-candidate-"))
 }
 
 function messages(error: unknown): string[] {
@@ -195,6 +204,91 @@ test("clean success restores overlays and releases the lock", async () => {
   ])
 })
 
+test("an owner write failure never publishes a visible lock", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-owner-write-"))
+  const lock = path.join(directory, "lock")
+  const failure = new Error("injected owner write failure")
+
+  try {
+    await expect(
+      acquireEngineOverlayLock(lock, {
+        beforeOwnerWrite: () => {
+          throw failure
+        },
+      }),
+    ).rejects.toBe(failure)
+    expect(exists(lock)).toBe(false)
+    expect(candidates(directory)).toEqual([])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("a crash after owner persistence but before publication leaves no visible lock", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-publish-crash-"))
+  const lock = path.join(directory, "lock")
+  const crashed = path.join(directory, "crashed")
+  const child = worker({
+    lock,
+    acquired: path.join(directory, "acquired"),
+    ready: path.join(directory, "ready"),
+    crashBeforePublish: crashed,
+    holdMs: 0,
+  })
+
+  try {
+    await waitFor(crashed)
+    await waitForExit(child)
+    expect(child.exitCode).toBe(70)
+    expect(exists(lock)).toBe(false)
+    expect(candidates(directory)).toHaveLength(1)
+
+    await acquireEngineOverlayLock(lock)
+    releaseEngineOverlayLock(lock)
+    expect(exists(lock)).toBe(false)
+  } finally {
+    await stop(child)
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("two processes racing initial publication admit exactly one writer", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-publish-race-"))
+  const lock = path.join(directory, "lock")
+  const synchronization = path.join(directory, "publish-ready")
+  const acquisitions = path.join(directory, "acquired")
+  mkdirSync(synchronization)
+
+  const first = worker({
+    lock,
+    acquired: acquisitions,
+    ready: path.join(directory, "first-ready"),
+    synchronizePublish: synchronization,
+    holdMs: 20_000,
+  })
+  const second = worker({
+    lock,
+    acquired: acquisitions,
+    ready: path.join(directory, "second-ready"),
+    synchronizePublish: synchronization,
+    holdMs: 20_000,
+  })
+
+  try {
+    await waitFor(acquisitions)
+    await Bun.sleep(500)
+    expect(acquired(acquisitions)).toHaveLength(1)
+    expect(
+      [exists(path.join(directory, "first-ready")), exists(path.join(directory, "second-ready"))].filter(Boolean),
+    ).toHaveLength(1)
+    assertRunning(first)
+    assertRunning(second)
+  } finally {
+    await Promise.all([stop(first), stop(second)])
+    rmSync(directory, { recursive: true, force: true })
+  }
+}, 10_000)
+
 test("a live lock excludes another process", async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-lock-"))
   const lock = path.join(directory, "lock")
@@ -277,6 +371,39 @@ test("a crash between stale quarantine and claim leaves the lock claimable", asy
     releaseEngineOverlayLock(lock)
     expect(exists(lock)).toBe(false)
     expect(exists(tombstone)).toBe(true)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("an empty ownerless legacy lock is quarantined only when upstream is clean", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-ownerless-clean-"))
+  const lock = path.join(directory, "lock")
+  mkdirSync(lock)
+
+  try {
+    await acquireEngineOverlayLock(lock, { upstreamChanges: async () => [] })
+    expect(exists(path.join(`${lock}-reclaimed`, "ownerless-legacy"))).toBe(true)
+    expect(JSON.parse(readFileSync(lock, "utf8"))).toMatchObject({ pid: process.pid })
+    releaseEngineOverlayLock(lock)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("an ownerless legacy lock fails closed when upstream is dirty", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-ownerless-dirty-"))
+  const lock = path.join(directory, "lock")
+  mkdirSync(lock)
+
+  try {
+    await expect(
+      acquireEngineOverlayLock(lock, {
+        upstreamChanges: async () => [" M engine/upstream/dirty.ts"],
+      }),
+    ).rejects.toThrow("Ownerless engine overlay lock cannot be recovered while engine/upstream is dirty")
+    expect(exists(lock)).toBe(true)
+    expect(exists(path.join(`${lock}-reclaimed`, "ownerless-legacy"))).toBe(false)
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }

--- a/tests/engine-overlays.test.ts
+++ b/tests/engine-overlays.test.ts
@@ -1,0 +1,140 @@
+import { expect, test } from "bun:test"
+import {
+  runWithEngineOverlays,
+  type EngineOverlayOperations,
+} from "../scripts/engine-overlays"
+
+function messages(error: unknown): string[] {
+  if (error instanceof AggregateError) return [error.message, ...error.errors.flatMap(messages)]
+  return [error instanceof Error ? error.message : String(error)]
+}
+
+function fixture(
+  overlays = ["one.patch"],
+  options: { applied?: string[]; dirty?: string[]; failedReversals?: string[] } = {},
+) {
+  const state = new Map(
+    overlays.map((overlay) => [
+      overlay,
+      options.dirty?.includes(overlay) ? "dirty" : options.applied?.includes(overlay) ? "applied" : "absent",
+    ]),
+  )
+  const events: string[] = []
+  const failedReversals = new Set(options.failedReversals)
+  const operations: EngineOverlayOperations = {
+    overlays,
+    acquireLock: async () => {
+      events.push("lock")
+    },
+    releaseLock: () => {
+      events.push("unlock")
+    },
+    canApply: async (overlay, reverse) => state.get(overlay) === (reverse ? "applied" : "absent"),
+    apply: async (overlay, reverse) => {
+      events.push(`${reverse ? "reverse" : "apply"}:${overlay}`)
+      if (reverse && failedReversals.has(overlay)) return false
+      state.set(overlay, reverse ? "absent" : "applied")
+      return true
+    },
+    upstreamChanges: async () =>
+      [...state]
+        .filter(([, value]) => value !== "absent")
+        .map(([overlay]) => ` M engine/upstream/${overlay}`),
+  }
+  return { events, operations }
+}
+
+test("successful callback fails and retains the lock when cleanup fails", async () => {
+  const { events, operations } = fixture(["one.patch"], { failedReversals: ["one.patch"] })
+
+  await expect(runWithEngineOverlays(async () => "ok", operations)).rejects.toThrow("Engine overlay restoration failed")
+  expect(events).toContain("reverse:one.patch")
+  expect(events).not.toContain("unlock")
+})
+
+test("callback and cleanup errors are both preserved", async () => {
+  const callbackError = new Error("callback failed")
+  const { operations } = fixture(["one.patch"], { failedReversals: ["one.patch"] })
+
+  try {
+    await runWithEngineOverlays(async () => {
+      throw callbackError
+    }, operations)
+    throw new Error("expected command failure")
+  } catch (error) {
+    expect(error).toBeInstanceOf(AggregateError)
+    expect((error as AggregateError).errors[0]).toBe(callbackError)
+    expect(messages(error)).toContain("callback failed")
+    expect(messages(error)).toContain("Failed to restore one.patch")
+  }
+})
+
+test("callback failure releases the lock after clean restoration", async () => {
+  const callbackError = new Error("callback failed")
+  const { events, operations } = fixture()
+
+  await expect(
+    runWithEngineOverlays(async () => {
+      throw callbackError
+    }, operations),
+  ).rejects.toBe(callbackError)
+  expect(events).toContain("unlock")
+})
+
+test("cleanup attempts every reversal in reverse order", async () => {
+  const { events, operations } = fixture(["one.patch", "two.patch", "three.patch"], {
+    failedReversals: ["one.patch", "three.patch"],
+  })
+
+  await expect(runWithEngineOverlays(async () => undefined, operations)).rejects.toThrow()
+  expect(events.filter((event) => event.startsWith("reverse:"))).toEqual([
+    "reverse:three.patch",
+    "reverse:two.patch",
+    "reverse:one.patch",
+  ])
+})
+
+test("unrecoverable startup state does not run the callback or release the lock", async () => {
+  const { events, operations } = fixture(["dirty.patch"], { dirty: ["dirty.patch"] })
+  let called = false
+
+  try {
+    await runWithEngineOverlays(async () => {
+      called = true
+    }, operations)
+    throw new Error("expected recovery failure")
+  } catch (error) {
+    expect(messages(error)).toContain(
+      "Startup recovery left engine/upstream dirty; manual recovery is required:\n M engine/upstream/dirty.patch",
+    )
+  }
+  expect(called).toBe(false)
+  expect(events).not.toContain("unlock")
+})
+
+test("startup reverses a recoverable interrupted overlay before running", async () => {
+  const { events, operations } = fixture(["one.patch"], { applied: ["one.patch"] })
+
+  expect(await runWithEngineOverlays(async () => "ok", operations)).toBe("ok")
+  expect(events).toEqual([
+    "lock",
+    "reverse:one.patch",
+    "apply:one.patch",
+    "reverse:one.patch",
+    "unlock",
+  ])
+})
+
+test("clean success restores overlays and releases the lock", async () => {
+  const { events, operations } = fixture(["one.patch", "two.patch"])
+
+  expect(await runWithEngineOverlays(async () => "result", operations)).toBe("result")
+  expect(events).toEqual([
+    "lock",
+    "apply:one.patch",
+    "apply:two.patch",
+    "reverse:two.patch",
+    "reverse:one.patch",
+    "unlock",
+  ])
+})

--- a/tests/engine-overlays.test.ts
+++ b/tests/engine-overlays.test.ts
@@ -66,7 +66,7 @@ function acquired(file: string) {
 }
 
 function candidates(directory: string) {
-  return readdirSync(directory).filter((entry) => entry.startsWith("lock-candidate-"))
+  return readdirSync(directory).filter((entry) => entry.includes("-candidate-"))
 }
 
 function messages(error: unknown): string[] {
@@ -390,6 +390,78 @@ test("an empty ownerless legacy lock is quarantined only when upstream is clean"
     rmSync(directory, { recursive: true, force: true })
   }
 })
+
+test("a legacy pid lock held by a live process keeps blocking", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-legacy-live-"))
+  const lock = path.join(directory, "lock")
+  const acquisitions = path.join(directory, "acquired")
+  const ready = path.join(directory, "ready")
+  mkdirSync(lock)
+  writeFileSync(path.join(lock, "pid"), `${process.pid}`)
+  const child = worker({ lock, acquired: acquisitions, ready, holdMs: 20_000 })
+
+  try {
+    await Bun.sleep(1_000)
+    expect(acquired(acquisitions)).toEqual([])
+    expect(exists(ready)).toBe(false)
+    expect(readFileSync(path.join(lock, "pid"), "utf8")).toBe(`${process.pid}`)
+    expect(exists(`${lock}-reclaimed`)).toBe(false)
+    assertRunning(child)
+  } finally {
+    await stop(child)
+    rmSync(directory, { recursive: true, force: true })
+  }
+}, 10_000)
+
+test("a legacy pid lock left by a dead process is reclaimed", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-legacy-dead-"))
+  const lock = path.join(directory, "lock")
+  mkdirSync(lock)
+
+  const exited = spawn(process.execPath, ["-e", ""])
+  await new Promise<void>((resolve) => exited.once("close", () => resolve()))
+  writeFileSync(path.join(lock, "pid"), `${exited.pid}`)
+  const reclaimed = path.join(`${lock}-reclaimed`, `legacy-pid-${exited.pid}`)
+
+  try {
+    await acquireEngineOverlayLock(lock)
+    expect(readFileSync(path.join(reclaimed, "pid"), "utf8")).toBe(`${exited.pid}`)
+    expect(JSON.parse(readFileSync(lock, "utf8"))).toMatchObject({ pid: process.pid })
+    releaseEngineOverlayLock(lock)
+    expect(exists(lock)).toBe(false)
+    expect(exists(reclaimed)).toBe(true)
+    expect(candidates(directory)).toEqual([])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("a malformed or crowded legacy pid lock fails closed", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-legacy-invalid-"))
+  const malformed = path.join(directory, "malformed")
+  const crowded = path.join(directory, "crowded")
+  mkdirSync(malformed)
+  writeFileSync(path.join(malformed, "pid"), "0x1f")
+  mkdirSync(crowded)
+  writeFileSync(path.join(crowded, "pid"), `${process.pid}`)
+  writeFileSync(path.join(crowded, "notes.txt"), "")
+
+  try {
+    await expect(acquireEngineOverlayLock(malformed, { upstreamChanges: async () => [] })).rejects.toThrow(
+      "Invalid engine overlay lock owner",
+    )
+    await expect(acquireEngineOverlayLock(crowded, { upstreamChanges: async () => [] })).rejects.toThrow(
+      "Ownerless engine overlay lock contains unexpected files",
+    )
+    for (const lock of [malformed, crowded]) {
+      expect(readFileSync(path.join(lock, "pid"), "utf8")).not.toBe("")
+      expect(exists(`${lock}-reclaimed`)).toBe(false)
+    }
+    expect(candidates(directory)).toEqual([])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+}, 10_000)
 
 test("an ownerless legacy lock fails closed when upstream is dirty", async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-ownerless-dirty-"))

--- a/tests/engine-overlays.test.ts
+++ b/tests/engine-overlays.test.ts
@@ -1,8 +1,64 @@
 import { expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import {
+  acquireEngineOverlayLock,
+  releaseEngineOverlayLock,
   runWithEngineOverlays,
   type EngineOverlayOperations,
 } from "../scripts/engine-overlays"
+
+const lockWorker = path.join(import.meta.dirname, "fixtures", "engine-overlay-lock-worker.ts")
+const workerErrors = new WeakMap<ReturnType<typeof spawn>, Buffer[]>()
+
+function exists(file: string) {
+  return existsSync(file)
+}
+
+async function waitFor(file: string, timeout = 5_000) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    if (exists(file)) return
+    await Bun.sleep(20)
+  }
+  throw new Error(`Timed out waiting for ${file}`)
+}
+
+function worker(input: Record<string, unknown>) {
+  const child = spawn(process.execPath, [lockWorker, JSON.stringify(input)], { stdio: "pipe" })
+  const errors: Buffer[] = []
+  child.stderr?.on("data", (data) => errors.push(Buffer.from(data)))
+  workerErrors.set(child, errors)
+  return child
+}
+
+function assertRunning(child: ReturnType<typeof worker>) {
+  if (child.exitCode === null) return
+  throw new Error(Buffer.concat(workerErrors.get(child) ?? []).toString() || `Lock worker exited ${child.exitCode}`)
+}
+
+async function stop(child: ReturnType<typeof worker>) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()))
+  if (process.platform === "win32" && child.pid) {
+    await new Promise<void>((resolve) =>
+      spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"]).once("close", () => resolve()),
+    )
+  }
+  child.kill()
+  await closed
+}
+
+function acquired(file: string) {
+  try {
+    return readFileSync(file, "utf8").split(/\r?\n/).filter(Boolean)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  }
+}
 
 function messages(error: unknown): string[] {
   if (error instanceof AggregateError) return [error.message, ...error.errors.flatMap(messages)]
@@ -137,4 +193,91 @@ test("clean success restores overlays and releases the lock", async () => {
     "reverse:one.patch",
     "unlock",
   ])
+})
+
+test("a live lock excludes another process", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-lock-"))
+  const lock = path.join(directory, "lock")
+  const acquisitions = path.join(directory, "acquired")
+  const firstReady = path.join(directory, "first-ready")
+  const secondReady = path.join(directory, "second-ready")
+  const first = worker({ lock, acquired: acquisitions, ready: firstReady, holdMs: 20_000 })
+  let second: ReturnType<typeof worker> | undefined
+
+  try {
+    await waitFor(firstReady)
+    second = worker({ lock, acquired: acquisitions, ready: secondReady, holdMs: 20_000 })
+    await Bun.sleep(500)
+    expect(acquired(acquisitions)).toHaveLength(1)
+    expect(exists(secondReady)).toBe(false)
+    assertRunning(first)
+    assertRunning(second)
+  } finally {
+    await Promise.all([stop(first), second ? stop(second) : Promise.resolve()])
+    rmSync(directory, { recursive: true, force: true })
+  }
+}, 10_000)
+
+test("two processes racing stale takeover admit exactly one writer", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-stale-lock-"))
+  const lock = path.join(directory, "lock")
+  const synchronization = path.join(directory, "dead-checks")
+  const acquisitions = path.join(directory, "acquired")
+  mkdirSync(lock)
+  mkdirSync(synchronization)
+
+  const exited = spawn(process.execPath, ["-e", ""])
+  await new Promise<void>((resolve) => exited.once("close", () => resolve()))
+  writeFileSync(
+    path.join(lock, "owner.json"),
+    JSON.stringify({ pid: exited.pid, token: "00000000-0000-4000-8000-000000000001" }),
+  )
+
+  const first = worker({
+    lock,
+    acquired: acquisitions,
+    ready: path.join(directory, "first-ready"),
+    synchronizeDeadCheck: synchronization,
+    holdMs: 20_000,
+  })
+  const second = worker({
+    lock,
+    acquired: acquisitions,
+    ready: path.join(directory, "second-ready"),
+    synchronizeDeadCheck: synchronization,
+    holdMs: 20_000,
+  })
+
+  try {
+    await waitFor(acquisitions)
+    await Bun.sleep(500)
+    expect(acquired(acquisitions)).toHaveLength(1)
+    expect(exists(path.join(`${lock}-reclaimed`, "00000000-0000-4000-8000-000000000001"))).toBe(true)
+    assertRunning(first)
+    assertRunning(second)
+  } finally {
+    await Promise.all([stop(first), stop(second)])
+    rmSync(directory, { recursive: true, force: true })
+  }
+}, 10_000)
+
+test("a crash between stale quarantine and claim leaves the lock claimable", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "drift-overlay-reclaim-crash-"))
+  const lock = path.join(directory, "lock")
+  const tombstone = path.join(`${lock}-reclaimed`, "00000000-0000-4000-8000-000000000001")
+  mkdirSync(tombstone, { recursive: true })
+  writeFileSync(
+    path.join(tombstone, "owner.json"),
+    JSON.stringify({ pid: process.pid + 1, token: "00000000-0000-4000-8000-000000000001" }),
+  )
+
+  try {
+    await acquireEngineOverlayLock(lock)
+    expect(exists(lock)).toBe(true)
+    releaseEngineOverlayLock(lock)
+    expect(exists(lock)).toBe(false)
+    expect(exists(tombstone)).toBe(true)
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
 })

--- a/tests/fixtures/engine-overlay-lock-worker.ts
+++ b/tests/fixtures/engine-overlay-lock-worker.ts
@@ -1,0 +1,37 @@
+import { appendFileSync, readdirSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { acquireEngineOverlayLock, releaseEngineOverlayLock } from "../../scripts/engine-overlays"
+
+interface Input {
+  lock: string
+  acquired: string
+  ready: string
+  synchronizeDeadCheck?: string
+  holdMs: number
+}
+
+const input = JSON.parse(process.argv[2]) as Input
+
+if (input.synchronizeDeadCheck) {
+  const kill = process.kill.bind(process)
+  Object.defineProperty(process, "kill", {
+    value: (...args: Parameters<typeof process.kill>) => {
+      try {
+        return kill(...args)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+        writeFileSync(path.join(input.synchronizeDeadCheck, String(process.pid)), "")
+        while (readdirSync(input.synchronizeDeadCheck!).length < 2) {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+        }
+        throw error
+      }
+    },
+  })
+}
+
+await acquireEngineOverlayLock(input.lock)
+appendFileSync(input.acquired, `${process.pid}\n`)
+writeFileSync(input.ready, "")
+await Bun.sleep(input.holdMs)
+releaseEngineOverlayLock(input.lock)

--- a/tests/fixtures/engine-overlay-lock-worker.ts
+++ b/tests/fixtures/engine-overlay-lock-worker.ts
@@ -7,6 +7,9 @@ interface Input {
   acquired: string
   ready: string
   synchronizeDeadCheck?: string
+  synchronizePublish?: string
+  publishContenders?: number
+  crashBeforePublish?: string
   holdMs: number
 }
 
@@ -30,7 +33,19 @@ if (input.synchronizeDeadCheck) {
   })
 }
 
-await acquireEngineOverlayLock(input.lock)
+await acquireEngineOverlayLock(input.lock, {
+  beforePublish: () => {
+    if (input.crashBeforePublish) {
+      writeFileSync(input.crashBeforePublish, "")
+      process.exit(70)
+    }
+    if (!input.synchronizePublish) return
+    writeFileSync(path.join(input.synchronizePublish, String(process.pid)), "")
+    while (readdirSync(input.synchronizePublish).length < (input.publishContenders ?? 2)) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10)
+    }
+  },
+})
 appendFileSync(input.acquired, `${process.pid}\n`)
 writeFileSync(input.ready, "")
 await Bun.sleep(input.holdMs)


### PR DESCRIPTION
## Summary

- attempt every overlay reversal and aggregate restoration failures
- preserve callback and cleanup errors while verifying `engine/upstream` is clean
- retain dirty locks and make interrupted-command recovery explicit
- add deterministic tooling tests and document the restoration contract

## Validation

- `bun test tests/engine-overlays.test.ts` (7 pass)
- `bun test tests` (125 pass)
- `bun run typecheck`
- `bun run test:engine`
- `bun run build:engine` (OpenCode 1.18.3 smoke passed)
- `git diff --exit-code -- engine/upstream`
- verified `engine/.overlay-lock` absent after engine test and build

Fixes #12