### PR TITLE
Detect stalled event streams and confirm cross-workspace permission replies

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -552,13 +552,19 @@ export function createActions(
     const permission = (state.permissions[sessionID] ?? []).find((p) => p.id === permissionID)
     const dir = permission?.metadata?.directory as string | undefined
     if (dir && normalizeDir(dir) !== normalizeDir(state.directory)) {
-      await replyElsewhere(sessionID, permissionID, response, dir)
+      // A swallowed failure would hide the card while the engine stays blocked on the ask, and
+      // because the card is gone poll reconciliation never clears it from `answered`.
+      if (!(await replyElsewhere(sessionID, permissionID, response, dir))) {
+        const message = "The request is still pending. Try again."
+        notice({ title: "Permission reply failed", message, variant: "error" })
+        return false
+      }
     } else {
       const result = await requireClient().postSessionIdPermissionsPermissionId({
         path: { id: sessionID, permissionID },
         body: { response },
       })
-      if (result.error) return
+      if (result.error) return false
     }
     answered.add(permissionID)
     set(
@@ -566,6 +572,7 @@ export function createActions(
         s.permissions[sessionID] = (s.permissions[sessionID] ?? []).filter((p) => p.id !== permissionID)
       }),
     )
+    return true
   }
 
   async function answerQuestion(sessionID: string, requestID: string, answers: string[][] | null) {
@@ -592,13 +599,14 @@ export function createActions(
 
   async function replyElsewhere(sessionID: string, permissionID: string, response: PermissionResponse, dir: string) {
     const base = target()
-    if (!base) return
+    if (!base) return false
     const url = `${base.url}/session/${sessionID}/permissions/${permissionID}?directory=${encodeURIComponent(dir)}`
-    await fetch(url, {
+    const result = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json", ...base.headers },
       body: JSON.stringify({ response }),
-    }).catch(() => {})
+    }).catch(() => null)
+    return result?.ok === true
   }
 
   async function interrupt(id: string) {

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -551,20 +551,27 @@ export function createActions(
   async function replyPermission(sessionID: string, permissionID: string, response: PermissionResponse) {
     const permission = (state.permissions[sessionID] ?? []).find((p) => p.id === permissionID)
     const dir = permission?.metadata?.directory as string | undefined
+    const failed = () => {
+      const message = "The request is still pending. Try again."
+      notice({ title: "Permission reply failed", message, variant: "error" })
+      return false
+    }
     if (dir && normalizeDir(dir) !== normalizeDir(state.directory)) {
       // A swallowed failure would hide the card while the engine stays blocked on the ask, and
       // because the card is gone poll reconciliation never clears it from `answered`.
-      if (!(await replyElsewhere(sessionID, permissionID, response, dir))) {
-        const message = "The request is still pending. Try again."
-        notice({ title: "Permission reply failed", message, variant: "error" })
-        return false
-      }
+      if (!(await replyElsewhere(sessionID, permissionID, response, dir))) return failed()
     } else {
-      const result = await requireClient().postSessionIdPermissionsPermissionId({
-        path: { id: sessionID, permissionID },
-        body: { response },
-      })
-      if (result.error) return false
+      // requireClient() throws while offline and the request itself can reject. UI callers
+      // fire-and-forget this action, so both must resolve to a visible failure.
+      try {
+        const result = await requireClient().postSessionIdPermissionsPermissionId({
+          path: { id: sessionID, permissionID },
+          body: { response },
+        })
+        if (result.error) return failed()
+      } catch {
+        return failed()
+      }
     }
     answered.add(permissionID)
     set(

--- a/src/engine/sse.ts
+++ b/src/engine/sse.ts
@@ -1,26 +1,64 @@
 import type { Event } from "@opencode-ai/sdk/client"
 import type { EngineTarget } from "./connection"
 
+// The engine heartbeats every 10s, so silence means the socket is half-open (proxy, VPN,
+// sleep/resume) and reader.read() would park forever, leaving Drift falsely online on stale
+// state. The margin absorbs scheduler jitter and proxy buffering without hiding a dead link.
+export const eventInactivityMs = 25_000
+
 export async function streamEvents(
   target: EngineTarget,
   signal: AbortSignal,
   onEvent: (event: Event, directory?: string) => void,
+  inactivityMs = eventInactivityMs,
 ) {
-  const res = await fetch(`${target.url}/global/event`, { headers: target.headers, signal })
-  if (!res.ok || !res.body) throw new Error(`event stream ${res.status}`)
-  const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ""
-  for (;;) {
-    const chunk = await reader.read()
-    if (chunk.done) return
-    buffer += decoder.decode(chunk.value, { stream: true })
-    const lines = buffer.split("\n")
-    buffer = lines.pop() ?? ""
-    for (const line of lines) {
-      const event = parseLine(line)
-      if (event) onEvent(event.payload, event.directory)
+  const controller = new AbortController()
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let inactive = false
+  const cancelReader = () => void reader?.cancel().catch(() => undefined)
+  const onAbort = () => {
+    controller.abort(signal.reason)
+    cancelReader()
+  }
+  // Any frame rearms the deadline, heartbeats included: this watches the socket, not payloads.
+  const arm = () => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      inactive = true
+      controller.abort("event stream inactive")
+      cancelReader()
+    }, inactivityMs)
+  }
+  signal.addEventListener("abort", onAbort, { once: true })
+  if (signal.aborted) onAbort()
+  arm()
+  try {
+    const res = await fetch(`${target.url}/global/event`, { headers: target.headers, signal: controller.signal })
+    if (!res.ok || !res.body) throw new Error(`event stream ${res.status}`)
+    reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+    for (;;) {
+      const chunk = await reader.read()
+      // Cancelling resolves the pending read as done; throw so the reconnect loop runs.
+      if (inactive) throw new Error("event stream inactive")
+      if (chunk.done) return
+      arm()
+      buffer += decoder.decode(chunk.value, { stream: true })
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+      for (const line of lines) {
+        const event = parseLine(line)
+        if (event) onEvent(event.payload, event.directory)
+      }
     }
+  } finally {
+    if (timer) clearTimeout(timer)
+    timer = undefined
+    signal.removeEventListener("abort", onAbort)
+    controller.abort()
+    await reader?.cancel().catch(() => undefined)
   }
 }
 

--- a/tests/permission-reply.test.ts
+++ b/tests/permission-reply.test.ts
@@ -72,6 +72,25 @@ test("a 500 from a cross-workspace reply keeps the ask visible and retryable", a
   expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
 })
 
+// UI callers fire-and-forget this action, so an offline client must surface a failure
+// rather than reject and silently leave the card in place with no explanation.
+test("a local reply that throws while offline keeps the ask visible and reports it", async () => {
+  const [state, set] = createEngineState()
+  set("directory", home)
+  set("permissions", "s1", [{ ...permission(), metadata: { directory: home } } as Permission])
+  const actions = createActions(
+    () => {
+      throw new Error("engine offline")
+    },
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+  expect(await actions.replyPermission("s1", "p1", "once")).toBe(false)
+  expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
+  expect(state.notices.at(-1)?.variant).toBe("error")
+})
+
 test("a confirmed cross-workspace reply clears the ask and survives a racing poll", async () => {
   const { state, actions, pending } = harness(async () => new Response(null, { status: 200 }))
   expect(await actions.replyPermission("s1", "p1", "once")).toBe(true)

--- a/tests/permission-reply.test.ts
+++ b/tests/permission-reply.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, expect, test } from "bun:test"
+import type { Permission } from "@opencode-ai/sdk/client"
+import { createActions } from "../src/engine/actions"
+import { createEngineState } from "../src/engine/store"
+
+if (!("localStorage" in globalThis))
+  Object.defineProperty(globalThis, "localStorage", {
+    value: { getItem: () => null, setItem: () => undefined },
+  })
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const home = "C:/one"
+const elsewhere = "C:/two"
+
+function permission(): Permission {
+  return {
+    id: "p1",
+    type: "bash",
+    sessionID: "s1",
+    messageID: "m1",
+    title: "rm -rf",
+    metadata: { directory: elsewhere },
+    time: { created: 1 },
+  } as Permission
+}
+
+// The engine keeps reporting the ask until it is actually answered, which is what makes a
+// swallowed reply failure permanent: the card is gone so reconciliation never revisits it.
+function harness(reply: () => Promise<Response>) {
+  const [state, set] = createEngineState()
+  set("directory", home)
+  set("permissions", "s1", [permission()])
+  const pending = { value: true }
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init)
+    const url = new URL(request.url)
+    if (request.method === "POST") return reply()
+    if (url.pathname === "/permission")
+      return Response.json(
+        pending.value ? [{ id: "p1", sessionID: "s1", permission: "bash", metadata: { title: "rm -rf" } }] : [],
+      )
+    return Response.json([])
+  }) as typeof fetch
+  const actions = createActions(
+    () => ({}) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+  return { state, actions, pending }
+}
+
+test("a rejected cross-workspace reply keeps the ask visible and retryable", async () => {
+  const { state, actions } = harness(() => Promise.reject(new Error("network down")))
+  expect(await actions.replyPermission("s1", "p1", "once")).toBe(false)
+  expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
+  expect(state.notices.at(-1)?.variant).toBe("error")
+  await actions.refreshPermissions([elsewhere])
+  expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
+})
+
+test("a 500 from a cross-workspace reply keeps the ask visible and retryable", async () => {
+  const { state, actions } = harness(async () => new Response("boom", { status: 500 }))
+  expect(await actions.replyPermission("s1", "p1", "once")).toBe(false)
+  expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
+  expect(state.notices.at(-1)?.variant).toBe("error")
+  await actions.refreshPermissions([elsewhere])
+  expect(state.permissions.s1?.map((item) => item.id)).toEqual(["p1"])
+})
+
+test("a confirmed cross-workspace reply clears the ask and survives a racing poll", async () => {
+  const { state, actions, pending } = harness(async () => new Response(null, { status: 200 }))
+  expect(await actions.replyPermission("s1", "p1", "once")).toBe(true)
+  expect(state.permissions.s1 ?? []).toHaveLength(0)
+  expect(state.notices).toHaveLength(0)
+  await actions.refreshPermissions([elsewhere])
+  expect(state.permissions.s1 ?? []).toHaveLength(0)
+  pending.value = false
+  await actions.refreshPermissions([elsewhere])
+  expect(state.permissions.s1 ?? []).toHaveLength(0)
+})

--- a/tests/stream-watchdog.test.ts
+++ b/tests/stream-watchdog.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, expect, test } from "bun:test"
+import type { Event } from "@opencode-ai/sdk/client"
+import { streamEvents } from "../src/engine/sse"
+
+const originalFetch = globalThis.fetch
+const originalSetTimeout = globalThis.setTimeout
+const originalClearTimeout = globalThis.clearTimeout
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  globalThis.setTimeout = originalSetTimeout
+  globalThis.clearTimeout = originalClearTimeout
+})
+
+// A stream that never closes on its own, so only the watchdog can end the read.
+function openStream() {
+  let push: (frame: string) => void = () => undefined
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      push = (frame) => controller.enqueue(new TextEncoder().encode(frame))
+    },
+  })
+  globalThis.fetch = (async () => new Response(body, { status: 200 })) as typeof fetch
+  return { push }
+}
+
+function frame(payload: unknown, directory = "C:/one") {
+  return `data: ${JSON.stringify({ directory, payload })}\n`
+}
+
+function trackTimers() {
+  const pending = new Set<unknown>()
+  globalThis.setTimeout = ((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+    const id = originalSetTimeout(
+      () => {
+        pending.delete(id)
+        ;(handler as (...rest: unknown[]) => void)(...args)
+      },
+      delay,
+    )
+    pending.add(id)
+    return id
+  }) as typeof setTimeout
+  globalThis.clearTimeout = ((id?: unknown) => {
+    pending.delete(id)
+    originalClearTimeout(id as Parameters<typeof clearTimeout>[0])
+  }) as typeof clearTimeout
+  return pending
+}
+
+test("a silent stream trips the inactivity deadline so the reconnect loop runs", async () => {
+  openStream()
+  const events: Event[] = []
+  const started = Date.now()
+  await expect(
+    streamEvents({ url: "http://engine.test" }, new AbortController().signal, (event) => events.push(event), 60),
+  ).rejects.toThrow(/inactive/)
+  expect(Date.now() - started).toBeLessThan(2000)
+  expect(events).toHaveLength(0)
+})
+
+test("heartbeats alone keep the stream alive", async () => {
+  const stream = openStream()
+  const events: Event[] = []
+  const controller = new AbortController()
+  const pump = streamEvents({ url: "http://engine.test" }, controller.signal, (event) => events.push(event), 80)
+  let settled: unknown
+  void pump.then(
+    () => (settled = "resolved"),
+    (error) => (settled = error),
+  )
+  for (let i = 0; i < 8; i++) {
+    stream.push(frame({ type: "server.heartbeat" }))
+    await Bun.sleep(20)
+  }
+  // Well past the deadline had heartbeats not rearmed it, and still no delivered events.
+  expect(settled).toBeUndefined()
+  expect(events).toHaveLength(0)
+  stream.push(frame({ type: "session.idle", properties: { sessionID: "s1" } }))
+  await Bun.sleep(10)
+  expect(events.map((event) => event.type)).toEqual(["session.idle"])
+  controller.abort()
+  await pump.catch(() => undefined)
+})
+
+test("the watchdog timer is cleared on abort and on normal exit", async () => {
+  const pending = trackTimers()
+  const stream = openStream()
+  const controller = new AbortController()
+  const pump = streamEvents({ url: "http://engine.test" }, controller.signal, () => undefined, 5_000)
+  stream.push(frame({ type: "server.heartbeat" }))
+  await Bun.sleep(20)
+  expect(pending.size).toBe(1)
+  controller.abort()
+  await pump.catch(() => undefined)
+  expect(pending.size).toBe(0)
+
+  globalThis.fetch = (async () => new Response(new ReadableStream({ start: (c) => c.close() }))) as typeof fetch
+  await streamEvents({ url: "http://engine.test" }, new AbortController().signal, () => undefined, 5_000)
+  expect(pending.size).toBe(0)
+})


### PR DESCRIPTION
﻿Fixes #15
Fixes #4

## SSE inactivity watchdog (#15)

`streamEvents` waited on `reader.read()` forever, so a half-open connection (proxy, VPN, sleep/resume) left Drift falsely online on permanently stale state. The read is now guarded by an abortable inactivity deadline, rearmed by **any** received frame including the engine's 10s heartbeat. The default 25s budget leaves room for scheduler jitter and proxy buffering without letting a dead link linger.

On expiry the internal controller aborts, the reader is cancelled and the call throws, which drops into the existing reconnect loop in `src/engine/index.tsx` (offline -> backoff -> connecting). `index.tsx` needed no changes. The timer is cleared, the outer abort listener removed and the reader cancelled in a `finally`, on both the abort and the normal-exit path, so nothing leaks across reconnects.

## Cross-workspace permission reply (#4)

`replyElsewhere()` swallowed fetch rejections and never checked `response.ok`, so `replyPermission()` added the id to `answered` and dropped the card while the engine stayed blocked on the ask. With the card gone, poll reconciliation in `refreshPermissions()` never saw it again and so never cleared `answered` — the ask stayed invisible until restart.

`replyElsewhere()` now returns whether the engine confirmed with an OK response. `replyPermission()` mutates `answered` and local state only after that confirmation; otherwise it surfaces an error notice through the existing `notice()` helper and returns false, leaving the card visible and retryable. The local-workspace branch is unchanged apart from returning a boolean.

## Scope

Deliberately minimal and self-contained: no generation tokens, no snapshot reconciliation, no revision buffers, no hydration or transcript-loading changes.

## Validation

- `bun test tests` — 176 pass, 0 fail (170 before; the 6 new tests are listed below)
- `bun run typecheck` — clean
- `bun run build` — clean

New coverage:

- silent never-closing stream trips the deadline and throws so reconnect runs (verified to hang indefinitely without the fix)
- heartbeat frames alone keep the stream alive past several deadline windows, and are still filtered from delivered events
- watchdog timers are cleared on abort and on normal exit, asserted against instrumented `setTimeout`/`clearTimeout`
- cross-workspace reply on network rejection: card retained, error notice raised, and a following poll still reports the ask (proving `answered` untouched)
- same for a 500 response
- confirmed 200 still clears the card and survives a racing poll snapshot

Diff: 4 files, +251/-19 (production change is 2 files, +65/-19).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission replies now surface failures, keep the pending request available for retry, and show an error notice instead of silently hiding it.
  * Successful permission replies are reliably cleared, including across subsequent refreshes.
  * Event streams now detect inactivity and terminate/trigger recovery rather than stalling indefinitely.
* **Reliability**
  * Added a heartbeat/inactivity watchdog to keep active streams responsive while closing stalled ones.
* **Tests**
  * Expanded coverage for permission reply outcomes and SSE inactivity/heartbeat behavior, including cleanup on abort/exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->