### PR TITLE
test: allow slower engine integration startup

### DIFF
--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -16,7 +16,7 @@ function engineEnvironment(extra: Record<string, string> = {}) {
 }
 
 async function run(directory: string, args: string[], env?: Record<string, string>) {
-  const child = Bun.spawn([process.execPath, "test", "--timeout", "20000", ...args], {
+  const child = Bun.spawn([process.execPath, "test", "--timeout", "60000", ...args], {
     cwd: path.join(engineUpstream, directory),
     env: engineEnvironment(env),
     stdin: "inherit",


### PR DESCRIPTION
## Summary
- raise the engine harness per-test timeout from 20 to 60 seconds
- preserve timeout-based hang detection while accommodating cold Windows CI startup

## Verification
- bun run test:engine
- bun run typecheck
- bun run test
- bun run test:release-policy