### PR TITLE
test: remove models.dev fetch from engine test timeouts

### DIFF
--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -12,7 +12,8 @@ function engineEnvironment(extra: Record<string, string> = {}) {
     "OPENCODE_SERVER_USERNAME",
   ])
     delete env[key]
-  return { ...env, ...extra }
+  // Bootstrap forks a models.dev catalog refresh that lands inside the first test's timeout.
+  return { ...env, OPENCODE_DISABLE_MODELS_FETCH: "1", ...extra }
 }
 
 async function run(directory: string, args: string[], env?: Record<string, string>) {


### PR DESCRIPTION
The v1.2.0 and v1.2.1 release runs both failed validation on `InstanceStore.provide runs InstanceBootstrap before effect`.

Root cause: building the bootstrap layer graph forks a models.dev catalog refresh (`core/src/models-dev.ts:249`). On a fresh CI runner that downloads a 3.2 MB `api.json` inside the first test's timeout window, and the 5 minute mtime TTL means it re-fires on essentially every cold start.

Measured on Windows, first test in `test/project/instance-bootstrap.test.ts`:

- cold cache, fetch enabled: 70s
- warm cache: 22s
- fetch disabled: 25s

CI saw 37s (passing CI run) and >60s (failing release run) for the same commit, which is why bumping the timeout 20s -> 60s did not help.

`OPENCODE_DISABLE_MODELS_FETCH` only skips the background refresh fiber and the network fallback. `populate` still reads the on-disk cache and the compiled-in snapshot first, so no test loses catalog data. Full engine suite passes with a deleted `models.json` and never re-creates it.

The 60s timeout is left in place as headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure stability to ensure more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->