### PR TITLE
test: raise engine test timeout above CI bootstrap cost

### DIFF
--- a/scripts/test-engine.ts
+++ b/scripts/test-engine.ts
@@ -16,8 +16,11 @@ function engineEnvironment(extra: Record<string, string> = {}) {
   return { ...env, OPENCODE_DISABLE_MODELS_FETCH: "1", ...extra }
 }
 
+// Instance bootstrap costs ~20s locally and ~50s on CI runners, so this only guards against hangs.
+const testTimeoutMs = 180_000
+
 async function run(directory: string, args: string[], env?: Record<string, string>) {
-  const child = Bun.spawn([process.execPath, "test", "--timeout", "60000", ...args], {
+  const child = Bun.spawn([process.execPath, "test", "--timeout", String(testTimeoutMs), ...args], {
     cwd: path.join(engineUpstream, directory),
     env: engineEnvironment(env),
     stdin: "inherit",


### PR DESCRIPTION
Follow-up to #42. That change removed the models.dev fetch from the timed window, which was worth doing (70s -> 25s locally for the first bootstrap test), but it did not fix CI.

Per-process wall times from the post-#42 master run, all against `packages/opencode`:

| process | time |
| --- | --- |
| move-session (core) | 7.4s |
| instance-bootstrap 1/4 | 50.9s |
| instance-bootstrap 2/4 | 44.8s |
| instance-bootstrap 3/4 | 44.6s |
| instance-bootstrap 4/4 | 54.1s |
| mcp lifecycle (required Drift mode) | 70.9s, timed out |

Every process costs ~45-55s, not just the first, so this is not a cold transpile that amortises. It is the instance bootstrap work itself: ~20s locally, ~2.5x that on a CI runner. `required Drift mode keeps captured auth ...` already took 51.3s on the last *passing* run, so it was ~9s from the limit before any of this.

Raising to 180s leaves the timeout doing what it should - catching hangs - instead of racing legitimate startup. It does not slow passing runs.

Not doing here: `test/project/instance-bootstrap.test.ts` is spawned four times because the overlay tests mutate `DRIFT_MCP_APPROVAL_REQUIRED` and depend on per-process config sealing. Collapsing those into one process would cut several minutes off the step but needs the sealing semantics checked properly, which does not belong in a release fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the engine test timeout to reduce failures caused by slow startup or execution environments.
  * Added configurable timeout handling for more reliable test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->