### PR TITLE
fix: expand release policy env vars in the pwsh publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         id: final-policy
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: bun scripts/release-policy.ts check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"
+        run: bun scripts/release-policy.ts check "$env:GITHUB_REF_NAME" "$env:GITHUB_SHA" "$env:GITHUB_RUN_ID"
 
       - name: Publish stable GitHub release
         if: steps.final-policy.outputs.published != 'true'

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -294,7 +294,13 @@ test("release workflow uses immutable action pins and triggering SHA binding", (
 
   expect(actions.length).toBeGreaterThan(0)
   for (const action of actions) expect(action).toMatch(/^[^@]+@[0-9a-f]{40}$/)
-  expect(workflow).toContain('check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"')
+  // Each job must bind the triggering ref/sha/run using its own shell: bash on ubuntu, pwsh on windows.
+  expect(workflow.slice(workflow.indexOf("  tag-policy:"), workflow.indexOf("  validation:"))).toContain(
+    'check "$GITHUB_REF_NAME" "$GITHUB_SHA" "$GITHUB_RUN_ID"',
+  )
+  expect(workflow.slice(workflow.indexOf("  publish:"))).toContain(
+    'check "$env:GITHUB_REF_NAME" "$env:GITHUB_SHA" "$env:GITHUB_RUN_ID"',
+  )
   expect(workflow).toContain("bun-version: 1.3.14")
   expect(workflow).not.toContain("bun-version: latest")
 })


### PR DESCRIPTION
The v1.2.2 release built and signed correctly, then died in `publish`:

```
error: Missing GitHub release environment
```

The `publish` job runs on `windows-latest`, so its default shell is pwsh, but the revalidate step used bash-style `$GITHUB_REF_NAME` expansion. pwsh treats those as undefined PowerShell variables, so `release-policy.ts check` received three empty strings and tripped its own environment guard.

The identical line in `tag-policy` (line 39) is correct because that job runs on `ubuntu-latest`. Every other Windows step in this file already uses the `$env:` form (the stamp and seal steps), so this was the one that got missed.

This never surfaced before because no release had reached `publish` since the workflow was last changed. v1.2.0, v1.2.1 and v1.2.2 all failed earlier, in validation.

Note that re-running the failed job on the existing tag would not work either: the artifact name embeds `github.run_attempt`, so a second attempt looks for an upload that does not exist. A new tag is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved publishing release validation by correctly passing tag name, commit SHA, and workflow run ID into the release policy check for both shell environments.
* **Tests**
  * Refined release-policy workflow assertions to more precisely verify the exact commands used in the tag-policy and publish steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->