### PR TITLE
fix: stage release assets flat so publication globs resolve

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,20 +156,25 @@ jobs:
           RELEASE_NOTES_MODEL: openai/gpt-4.1
         run: bun scripts/release-notes.ts release-notes.md
 
+      # Uploading a single directory keeps the artifact flat; multiple paths root it at their common ancestor.
+      - name: Stage release artifacts
+        shell: pwsh
+        run: |
+          $bundle = "src-tauri/target/release/bundle/nsis"
+          New-Item -ItemType Directory -Path release-artifacts | Out-Null
+          Copy-Item "$bundle/*-setup.exe", "$bundle/*.sig", "$bundle/latest.json" release-artifacts
+          Move-Item release-notes.md release-artifacts
+
       - name: Seal release notes and asset digests
         run: >-
-          bun scripts/release-policy.ts seal release-notes.md "$env:GITHUB_RUN_ID"
-          "${{ needs.tag-policy.outputs.commit }}" "src-tauri/target/release/bundle/nsis"
+          bun scripts/release-policy.ts seal release-artifacts/release-notes.md "$env:GITHUB_RUN_ID"
+          "${{ needs.tag-policy.outputs.commit }}" "release-artifacts"
 
       - name: Upload signed release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.tag-policy.outputs.commit }}
-          path: |
-            src-tauri/target/release/bundle/nsis/*-setup.exe
-            src-tauri/target/release/bundle/nsis/*.sig
-            src-tauri/target/release/bundle/nsis/latest.json
-            release-notes.md
+          path: release-artifacts
           if-no-files-found: error
           retention-days: 1
 

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -322,3 +322,19 @@ test("release workflow serializes tags globally and rechecks full policy immedia
   expect(publish).toContain("if: steps.final-policy.outputs.published != 'true'")
   expect(workflow).toContain("release-${{ github.run_id }}-${{ github.run_attempt }}-")
 })
+
+test("release assets are staged flat so publication globs resolve", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
+  const signing = workflow.slice(workflow.indexOf("  signed-artifacts:"), workflow.indexOf("  publish:"))
+  const publish = workflow.slice(workflow.indexOf("  publish:"))
+
+  // A multi-path upload roots the artifact at the common ancestor, which breaks the publication globs.
+  expect(signing).not.toContain("path: |")
+  expect(signing).toContain("path: release-artifacts")
+  expect(signing).toContain('"${{ needs.tag-policy.outputs.commit }}" "release-artifacts"')
+  expect(publish).toContain("path: release-artifacts")
+  expect(publish).toContain("body_path: release-artifacts/release-notes.md")
+  for (const asset of ["release-artifacts/*-setup.exe", "release-artifacts/*.sig", "release-artifacts/latest.json"]) {
+    expect(publish).toContain(asset)
+  }
+})

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -329,8 +329,8 @@ test("release assets are staged flat so publication globs resolve", () => {
   const publish = workflow.slice(workflow.indexOf("  publish:"))
 
   // A multi-path upload roots the artifact at the common ancestor, which breaks the publication globs.
-  expect(signing).not.toContain("path: |")
-  expect(signing).toContain("path: release-artifacts")
+  const upload = signing.slice(signing.indexOf("- name: Upload signed release artifacts"))
+  expect(upload.match(/^\s+path:\s*(.*)$/m)?.[1].trim()).toBe("release-artifacts")
   expect(signing).toContain('"${{ needs.tag-policy.outputs.commit }}" "release-artifacts"')
   expect(publish).toContain("path: release-artifacts")
   expect(publish).toContain("body_path: release-artifacts/release-notes.md")


### PR DESCRIPTION
v1.2.3 passed validation and signing (so #42, #43 and #44 all did their job), then failed at the last step:

```
Pattern 'release-artifacts/*-setup.exe' does not match any files.
```

The upload step listed four paths: three under `src-tauri/target/release/bundle/nsis/` and `release-notes.md` at the repo root. When `upload-artifact` is given multiple paths it roots the artifact at their least common ancestor, which here is the workspace root, so the installer kept its full nested path inside the artifact.

Downloading the v1.2.3 artifact confirms it:

```
release-notes.md
src-tauri/target/release/bundle/nsis/Drift_1.2.3_x64-setup.exe
src-tauri/target/release/bundle/nsis/Drift_1.2.3_x64-setup.exe.sig
src-tauri/target/release/bundle/nsis/latest.json
```

`body_path: release-artifacts/release-notes.md` happened to resolve, which is why only the installer glob was reported.

Rather than teach the publish job the nested path, the signing job now copies the three assets plus the notes into a single `release-artifacts/` directory and uploads that one directory. A single-directory upload is rooted at that directory, so the artifact is flat and the existing publication globs resolve as written. Sealing now runs against the staged directory, which is also a better description of intent: the thing that gets hashed is exactly the thing that gets published.

This has never worked. The release workflow was restructured from one job into four with an artifact handoff after v1.1.2, and no release has reached publication since.

Verified locally:

- `sealReleaseNotes` against a staged directory containing the notes file: `isReleaseAsset` filters `release-notes.md` out, so it still seals exactly three assets.
- The pwsh staging commands, which produce the flat layout.

Added a test pinning the contract, including `not.toContain("path: |")`, so a future multi-path upload fails in CI instead of at publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release packaging by grouping installers, signatures, metadata, and release notes into a consistent artifact bundle.
  * Improved reliability when publishing signed releases by ensuring all expected files are uploaded and available together.
  * Added validation to help prevent missing or incorrectly located release assets during publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->