### PR TITLE
ci: reduce release time by reusing master validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,52 +41,43 @@ jobs:
   validation:
     needs: tag-policy
     if: needs.tag-policy.outputs.published != 'true'
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-          ref: ${{ needs.tag-policy.outputs.commit }}
-
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
-        with:
-          bun-version: 1.3.14
-
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-
-      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-        with:
-          workspaces: src-tauri
-
-      - name: Install dependencies
+      - name: Require successful master CI for the release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ needs.tag-policy.outputs.commit }}
         run: |
-          bun install --frozen-lockfile
-          bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
-          bun install --frozen-lockfile --cwd engine/opencode
-
-      - name: Typecheck
-        run: bun run typecheck
-
-      - name: Root tests
-        run: bun run test
-
-      - name: Engine integration tests
-        run: bun run test:engine
-
-      - name: Build engine
-        run: bun run build:engine
-
-      - name: Native unit tests
-        run: cargo test --locked --manifest-path src-tauri/Cargo.toml
-
-      - name: Stamp release version
-        run: bun scripts/release-policy.ts stamp "$env:GITHUB_REF_NAME"
-
-      - name: Production UI and package assembly
-        run: bun run build:native
+          deadline=$((SECONDS + 1800))
+          while (( SECONDS < deadline )); do
+            row="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$COMMIT&event=push&per_page=10" \
+              --jq '.workflow_runs | map(select(.head_branch == "master")) | sort_by(.run_number) | last | if . then [.status, (.conclusion // ""), .html_url] | @tsv else "" end')"
+            if [[ -z "$row" ]]; then
+              echo "Waiting for master CI run for $COMMIT"
+              sleep 15
+              continue
+            fi
+            IFS=$'\t' read -r status conclusion url <<< "$row"
+            if [[ "$status" != "completed" ]]; then
+              echo "Waiting for $url ($status)"
+              sleep 15
+              continue
+            fi
+            if [[ "$conclusion" != "success" ]]; then
+              echo "Master CI did not pass: $url ($conclusion)" >&2
+              exit 1
+            fi
+            echo "Using successful master CI: $url"
+            exit 0
+          done
+          echo "Timed out waiting for master CI for $COMMIT" >&2
+          exit 1
 
   signed-artifacts:
-    needs: [tag-policy, validation]
+    needs: tag-policy
     if: needs.tag-policy.outputs.published != 'true'
     runs-on: windows-latest
     permissions:

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -263,7 +263,7 @@ test("release stamping updates every package version and is idempotent", () => {
   }
 })
 
-test("release workflow gates secrets and publication on policy and full validation", () => {
+test("release workflow gates publication on policy and successful master CI", () => {
   const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
   const validation = workflow.slice(workflow.indexOf("  validation:"), workflow.indexOf("  signed-artifacts:"))
   const signing = workflow.slice(workflow.indexOf("  signed-artifacts:"), workflow.indexOf("  publish:"))
@@ -271,18 +271,17 @@ test("release workflow gates secrets and publication on policy and full validati
 
   expect(workflow).toContain("needs: tag-policy")
   expect(workflow).toContain("if: needs.tag-policy.outputs.published != 'true'")
-  expect(signing).toContain("needs: [tag-policy, validation]")
+  expect(signing).toContain("needs: tag-policy")
   expect(publish).toContain("needs: [tag-policy, validation, signed-artifacts]")
   expect(validation).not.toContain("secrets.")
-  for (const command of [
-    "bun install --frozen-lockfile",
-    "bun run typecheck",
-    "bun run test",
-    "bun run test:engine",
-    "bun run build:engine",
-    "cargo test --locked --manifest-path src-tauri/Cargo.toml",
-    "bun run build:native",
-  ]) expect(validation).toContain(command)
+  expect(validation).toContain("actions: read")
+  expect(validation).toContain("actions/workflows/ci.yml/runs?head_sha=$COMMIT&event=push")
+  expect(validation).toContain('select(.head_branch == "master")')
+  expect(validation).toContain('if [[ "$conclusion" != "success" ]]')
+  expect(validation).toContain("Timed out waiting for master CI")
+  for (const command of ["bun run test:engine", "cargo test", "bun run build:native"]) {
+    expect(validation).not.toContain(command)
+  }
   expect(signing).toContain("contents: read")
   expect(signing).not.toContain("contents: write")
   expect(signing).toContain("persist-credentials: false")


### PR DESCRIPTION
## Summary
- replace duplicate tag-time test/build validation with a gate on the exact commit's successful master CI run
- start signed artifact construction in parallel with that validation gate
- preserve publication dependency on both CI validation and signed artifacts

## Expected impact
The v1.2.5 critical path was 10s policy + 18m41s duplicate validation + 10m46s signing + 36s publish (~30m). This makes validation and signing concurrent and reuses master CI, reducing tag-to-release time to roughly the ~11-minute signed-build path.

## Verification
- bun run typecheck
- bun test tests (190 pass)
- release workflow policy tests (18 pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Release validation now waits for successful CI completion on the tagged commit before proceeding.
  * Improved release workflow permissions and added clear timeout and failure handling.
  * Signing and publication stages now follow streamlined validation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->