### PR TITLE
Only offer updates to installed builds

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,19 @@ copy, and revert action. Revert state comes from the engine session record; the 
 filters messages at that marker while `/undo` and `/redo` move it one user prompt at a
 time. Reverted prompt text is returned to the composer for editing.
 
+## Updates
+
+The updater only runs from an installed copy, detected by an `uninstall.exe` beside the
+executable. A locally built release binary lives in the cargo target directory, where an
+installer can never replace it, so offering an update there produced an endless prompt
+against a separately installed copy: the badge advertised the released version while the
+running executable and About kept reporting the older local build. Debug builds stay
+excluded as before, and About names the running kind so the two are never confused.
+
+Installing kills the engine sidecar between download and install. The Windows plugin
+exits the process without firing `RunEvent::Exit`, so the sidecar would otherwise survive
+and hold `drift-engine.exe` locked while NSIS tried to replace it.
+
 ## Known constraints
 
 - REST calls are scoped to the per-directory instance; the event stream is global.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,9 +118,12 @@ against a separately installed copy: the badge advertised the released version w
 running executable and About kept reporting the older local build. Debug builds stay
 excluded as before, and About names the running kind so the two are never confused.
 
-Installing kills the engine sidecar between download and install. The Windows plugin
-exits the process without firing `RunEvent::Exit`, so the sidecar would otherwise survive
-and hold `drift-engine.exe` locked while NSIS tried to replace it.
+Installing stops the engine sidecar between download and install, waiting for it to exit
+rather than only signalling it, because Windows keeps the executable locked until the
+process is gone. The plugin exits this process without firing `RunEvent::Exit`, so the
+sidecar would otherwise survive and hold `drift-engine.exe` locked while NSIS tried to
+replace it. An install that fails, most often a declined elevation prompt, leaves the app
+running, so the sidecar is started again from the parameters it was first launched with.
 
 ## Known constraints
 

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -8,6 +8,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use tauri::{Manager, State};
 
@@ -28,6 +29,8 @@ pub(crate) struct Engine {
     pub(crate) password: String,
     /// How the engine was launched, so a caller that stops it can start an equivalent one.
     launch: Mutex<Option<(bool, PathBuf)>>,
+    /// Bumped per spawn so a stopped engine's reader cannot publish over its replacement.
+    generation: AtomicU64,
 }
 
 impl Default for Engine {
@@ -40,6 +43,7 @@ impl Default for Engine {
             diagnostic: Mutex::new(String::new()),
             password: bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
             launch: Mutex::new(None),
+            generation: AtomicU64::new(0),
         }
     }
 }
@@ -123,7 +127,11 @@ pub(crate) fn engine_extensions() -> Option<std::path::PathBuf> {
 }
 
 pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBuf) {
-    *app.state::<Engine>().launch.lock().unwrap() = Some((shared_database, config_dir.clone()));
+    let generation = {
+        let engine = app.state::<Engine>();
+        *engine.launch.lock().unwrap() = Some((shared_database, config_dir.clone()));
+        engine.generation.fetch_add(1, Ordering::SeqCst) + 1
+    };
     std::thread::spawn(move || {
         let Some(binary) = engine_binary() else {
             *app.state::<Engine>().diagnostic.lock().unwrap() =
@@ -177,13 +185,19 @@ pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_
             });
         }
         let Some(stdout) = stdout else { return };
+        let current = || app.state::<Engine>().generation.load(Ordering::SeqCst) == generation;
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
             if let Some(index) = line.find("http://") {
                 let engine = app.state::<Engine>();
-                *engine.url.lock().unwrap() = Some(line[index..].trim().to_string());
+                if current() {
+                    *engine.url.lock().unwrap() = Some(line[index..].trim().to_string());
+                }
             }
         }
-        *app.state::<Engine>().url.lock().unwrap() = None;
+        // A superseded engine must not report its own exit as the current engine going down.
+        if current() {
+            *app.state::<Engine>().url.lock().unwrap() = None;
+        }
     });
 }
 

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -130,12 +130,16 @@ pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_
     let generation = {
         let engine = app.state::<Engine>();
         *engine.launch.lock().unwrap() = Some((shared_database, config_dir.clone()));
-        engine.generation.fetch_add(1, Ordering::SeqCst) + 1
+        let generation = engine.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        engine.diagnostic.lock().unwrap().clear();
+        generation
     };
     std::thread::spawn(move || {
         let Some(binary) = engine_binary() else {
-            *app.state::<Engine>().diagnostic.lock().unwrap() =
-                "embedded engine binary not found".into();
+            let engine = app.state::<Engine>();
+            if engine.generation.load(Ordering::SeqCst) == generation {
+                *engine.diagnostic.lock().unwrap() = "embedded engine binary not found".into();
+            }
             return;
         };
         let home = std::env::var("USERPROFILE").or_else(|_| std::env::var("HOME"));
@@ -165,21 +169,35 @@ pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_
         let mut child = match command.spawn() {
             Ok(child) => child,
             Err(error) => {
-                *app.state::<Engine>().diagnostic.lock().unwrap() =
-                    format!("failed to start embedded engine: {error}");
+                let engine = app.state::<Engine>();
+                if engine.generation.load(Ordering::SeqCst) == generation {
+                    *engine.diagnostic.lock().unwrap() =
+                        format!("failed to start embedded engine: {error}");
+                }
                 return;
             }
         };
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
         let engine = app.state::<Engine>();
-        *engine.child.lock().unwrap() = Some(child);
+        let mut slot = engine.child.lock().unwrap();
+        if engine.generation.load(Ordering::SeqCst) != generation || slot.is_some() {
+            drop(slot);
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        *slot = Some(child);
+        drop(slot);
         if let Some(stderr) = stderr {
             let diagnostics_app = app.clone();
             std::thread::spawn(move || {
                 for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                    if !line.trim().is_empty() {
-                        *diagnostics_app.state::<Engine>().diagnostic.lock().unwrap() = line;
+                    let engine = diagnostics_app.state::<Engine>();
+                    if engine.generation.load(Ordering::SeqCst) == generation
+                        && !line.trim().is_empty()
+                    {
+                        *engine.diagnostic.lock().unwrap() = line;
                     }
                 }
             });
@@ -201,12 +219,10 @@ pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_
     });
 }
 
-/// Stops the sidecar and waits for it to actually exit.
-///
-/// `kill` only signals; on Windows the executable stays locked until the process is gone, which
-/// would defeat an installer trying to replace `drift-engine.exe`.
+/// Stops the sidecar and waits until Windows releases the executable lock.
 pub(crate) fn stop_engine_child(app: &tauri::AppHandle) {
     let engine = app.state::<Engine>();
+    engine.generation.fetch_add(1, Ordering::SeqCst);
     let child = engine.child.lock().unwrap().take();
     if let Some(mut child) = child {
         let _ = child.kill();

--- a/src-tauri/src/engine.rs
+++ b/src-tauri/src/engine.rs
@@ -26,6 +26,8 @@ pub(crate) struct Engine {
     diagnostic: Mutex<String>,
     /// Random per run; the frontend receives it from `engine_status` and uses it for basic auth.
     pub(crate) password: String,
+    /// How the engine was launched, so a caller that stops it can start an equivalent one.
+    launch: Mutex<Option<(bool, PathBuf)>>,
 }
 
 impl Default for Engine {
@@ -37,6 +39,7 @@ impl Default for Engine {
             child: Mutex::new(None),
             diagnostic: Mutex::new(String::new()),
             password: bytes.iter().map(|byte| format!("{byte:02x}")).collect(),
+            launch: Mutex::new(None),
         }
     }
 }
@@ -120,6 +123,7 @@ pub(crate) fn engine_extensions() -> Option<std::path::PathBuf> {
 }
 
 pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_dir: PathBuf) {
+    *app.state::<Engine>().launch.lock().unwrap() = Some((shared_database, config_dir.clone()));
     std::thread::spawn(move || {
         let Some(binary) = engine_binary() else {
             *app.state::<Engine>().diagnostic.lock().unwrap() =
@@ -181,6 +185,28 @@ pub(crate) fn spawn_engine(app: tauri::AppHandle, shared_database: bool, config_
         }
         *app.state::<Engine>().url.lock().unwrap() = None;
     });
+}
+
+/// Stops the sidecar and waits for it to actually exit.
+///
+/// `kill` only signals; on Windows the executable stays locked until the process is gone, which
+/// would defeat an installer trying to replace `drift-engine.exe`.
+pub(crate) fn stop_engine_child(app: &tauri::AppHandle) {
+    let engine = app.state::<Engine>();
+    let child = engine.child.lock().unwrap().take();
+    if let Some(mut child) = child {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    *engine.url.lock().unwrap() = None;
+}
+
+/// Starts a replacement sidecar using the parameters the first one was launched with.
+pub(crate) fn respawn_engine(app: &tauri::AppHandle) {
+    let launch = app.state::<Engine>().launch.lock().unwrap().clone();
+    if let Some((shared_database, config_dir)) = launch {
+        spawn_engine(app.clone(), shared_database, config_dir);
+    }
 }
 
 pub(crate) fn stop_engine_instances(app: &tauri::AppHandle) -> Result<(), String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -38,6 +38,7 @@ fn main() {
             engine::engine_status,
             updater::check_update,
             updater::install_update,
+            updater::update_support,
             clipboard::clipboard_write_text,
             config::config_read,
             editor::pick_folder,

--- a/src-tauri/src/main_tests.rs
+++ b/src-tauri/src/main_tests.rs
@@ -5,6 +5,7 @@ use crate::clipboard::clipboard_utf16;
 use crate::config::config_path;
 use crate::editor::{editor_arguments, editor_kind, EditorKind};
 use crate::engine::{basic_authorization, Engine};
+use crate::updater::installed_alongside_uninstaller;
 use crate::watcher::{file_signatures, watched_mcp_paths};
 use std::path::Path;
 
@@ -48,6 +49,21 @@ fn engine_credentials_are_random_and_basic_auth_encoded() {
     assert_eq!(first.len(), 64);
     assert_ne!(first, second);
     assert_eq!(basic_authorization("user", "pass"), "dXNlcjpwYXNz");
+}
+
+#[test]
+fn updates_are_only_offered_next_to_the_uninstaller() {
+    let root = std::env::temp_dir().join(format!("drift-updater-test-{}", std::process::id()));
+    std::fs::remove_dir_all(&root).ok();
+    let installed = root.join("installed");
+    let portable = root.join("target/release");
+    std::fs::create_dir_all(&installed).unwrap();
+    std::fs::create_dir_all(&portable).unwrap();
+    std::fs::write(installed.join("uninstall.exe"), "nsis").unwrap();
+    assert!(installed_alongside_uninstaller(&installed.join("drift.exe")));
+    assert!(!installed_alongside_uninstaller(&portable.join("drift.exe")));
+    assert!(!installed_alongside_uninstaller(Path::new("drift.exe")));
+    std::fs::remove_dir_all(root).ok();
 }
 
 #[test]

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -2,18 +2,13 @@
 
 use std::path::Path;
 
-/// True when the executable sits in an NSIS-installed location (next to its uninstaller).
-///
-/// Local release builds run from a cargo target directory. The installer can never replace
-/// them, so offering updates there produces an endless "update available" loop against the
-/// separately installed copy.
+/// True when the executable sits in an NSIS-installed location next to its uninstaller.
 pub(crate) fn installed_alongside_uninstaller(exe: &Path) -> bool {
     exe.parent()
         .is_some_and(|dir| dir.join("uninstall.exe").is_file())
 }
 
-/// Debug builds never update: a local build's version usually trails the latest release, so it
-/// would otherwise be offered an "update" that replaces the build under development.
+/// Debug builds and local release builds cannot update themselves.
 fn updatable() -> bool {
     if cfg!(debug_assertions) {
         return false;
@@ -40,16 +35,7 @@ pub(crate) async fn check_update(app: tauri::AppHandle) -> Result<Option<String>
     Ok(update.map(|u| u.version))
 }
 
-/// Downloads and installs the pending update, then restarts.
-///
-/// The engine sidecar is stopped between download and install: the NSIS run replaces files in
-/// the install directory, and on Windows the plugin exits this process without firing
-/// `RunEvent::Exit`, so the sidecar would otherwise survive and hold `drift-engine.exe` locked.
-/// A failed install (a declined elevation prompt, most often) leaves the app running, so the
-/// sidecar is started again rather than leaving a live app with no engine.
-///
-/// Never returns on success: the installer exits the process on Windows and `app.restart()`
-/// diverges elsewhere, which is why there is no trailing `Ok(())`.
+/// Downloads the update, releases the sidecar executable, installs, and restarts.
 #[tauri::command]
 pub(crate) async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
     if !updatable() {

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,13 +1,39 @@
 //! Update check and install, delegated to the Tauri updater plugin.
 
-/// Returns the version of an available update, or `None` if the app is current.
+use std::path::Path;
+use tauri::Manager;
+
+/// True when the executable sits in an NSIS-installed location (next to its uninstaller).
 ///
-/// Debug builds never check: a local build's version usually trails the latest release, so it
-/// would otherwise be offered an "update" that replaces the build under development. In release
-/// builds the plugin compares semver against the manifest and only offers strictly newer versions.
+/// Local release builds run from a cargo target directory. The installer can never replace
+/// them, so offering updates there produces an endless "update available" loop against the
+/// separately installed copy.
+pub(crate) fn installed_alongside_uninstaller(exe: &Path) -> bool {
+    exe.parent()
+        .is_some_and(|dir| dir.join("uninstall.exe").is_file())
+}
+
+/// Debug builds never update: a local build's version usually trails the latest release, so it
+/// would otherwise be offered an "update" that replaces the build under development.
+fn updatable() -> bool {
+    if cfg!(debug_assertions) {
+        return false;
+    }
+    std::env::current_exe()
+        .map(|exe| installed_alongside_uninstaller(&exe))
+        .unwrap_or(false)
+}
+
+/// Whether this build can update itself, surfaced in About so a local build is recognizable.
+#[tauri::command]
+pub(crate) fn update_support() -> bool {
+    updatable()
+}
+
+/// Returns the version of an available update, or `None` if the app is current.
 #[tauri::command]
 pub(crate) async fn check_update(app: tauri::AppHandle) -> Result<Option<String>, String> {
-    if cfg!(debug_assertions) {
+    if !updatable() {
         return Ok(None);
     }
     let updater = tauri_plugin_updater::UpdaterExt::updater(&app).map_err(|e| e.to_string())?;
@@ -17,11 +43,16 @@ pub(crate) async fn check_update(app: tauri::AppHandle) -> Result<Option<String>
 
 /// Downloads and installs the pending update, then restarts.
 ///
-/// Never returns on success: `app.restart()` diverges, which is why there is no trailing `Ok(())`.
+/// The engine sidecar is killed between download and install: the NSIS run replaces files in
+/// the install directory, and on Windows the plugin exits this process without firing
+/// `RunEvent::Exit`, so the sidecar would otherwise survive and hold `drift-engine.exe` locked.
+///
+/// Never returns on success: the installer exits the process on Windows and `app.restart()`
+/// diverges elsewhere, which is why there is no trailing `Ok(())`.
 #[tauri::command]
 pub(crate) async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
-    if cfg!(debug_assertions) {
-        return Err("updates cannot be installed from debug builds".into());
+    if !updatable() {
+        return Err("updates can only be installed from an installed copy of Drift".into());
     }
     let updater = tauri_plugin_updater::UpdaterExt::updater(&app).map_err(|e| e.to_string())?;
     let update = updater
@@ -29,9 +60,14 @@ pub(crate) async fn install_update(app: tauri::AppHandle) -> Result<(), String> 
         .await
         .map_err(|e| e.to_string())?
         .ok_or("no update available")?;
-    update
-        .download_and_install(|_, _| {}, || {})
+    let bytes = update
+        .download(|_, _| {}, || {})
         .await
         .map_err(|e| e.to_string())?;
+    let child = app.state::<crate::engine::Engine>().child.lock().unwrap().take();
+    if let Some(mut child) = child {
+        let _ = child.kill();
+    }
+    update.install(bytes).map_err(|e| e.to_string())?;
     app.restart();
 }

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,7 +1,6 @@
 //! Update check and install, delegated to the Tauri updater plugin.
 
 use std::path::Path;
-use tauri::Manager;
 
 /// True when the executable sits in an NSIS-installed location (next to its uninstaller).
 ///
@@ -43,9 +42,11 @@ pub(crate) async fn check_update(app: tauri::AppHandle) -> Result<Option<String>
 
 /// Downloads and installs the pending update, then restarts.
 ///
-/// The engine sidecar is killed between download and install: the NSIS run replaces files in
+/// The engine sidecar is stopped between download and install: the NSIS run replaces files in
 /// the install directory, and on Windows the plugin exits this process without firing
 /// `RunEvent::Exit`, so the sidecar would otherwise survive and hold `drift-engine.exe` locked.
+/// A failed install (a declined elevation prompt, most often) leaves the app running, so the
+/// sidecar is started again rather than leaving a live app with no engine.
 ///
 /// Never returns on success: the installer exits the process on Windows and `app.restart()`
 /// diverges elsewhere, which is why there is no trailing `Ok(())`.
@@ -64,10 +65,10 @@ pub(crate) async fn install_update(app: tauri::AppHandle) -> Result<(), String> 
         .download(|_, _| {}, || {})
         .await
         .map_err(|e| e.to_string())?;
-    let child = app.state::<crate::engine::Engine>().child.lock().unwrap().take();
-    if let Some(mut child) = child {
-        let _ = child.kill();
+    crate::engine::stop_engine_child(&app);
+    if let Err(error) = update.install(bytes) {
+        crate::engine::respawn_engine(&app);
+        return Err(error.to_string());
     }
-    update.install(bytes).map_err(|e| e.to_string())?;
     app.restart();
 }


### PR DESCRIPTION
## Summary

Closes #51.

A release build run from the cargo target directory was offered updates it could never apply: the installer writes to the install directory, so the running executable was never replaced and the restart relaunched the same build. The badge returned on every launch, advertising the released version while the executable's properties and About truthfully reported the older local build. Together those readings made a correct release look broken.

Updates now require an installed copy, detected by an `uninstall.exe` beside the executable. Debug builds stay excluded as before. A new `update_support` command lets About name the running kind, so an installed copy and a local build cannot be confused again.

Installing also kills the engine sidecar between download and install. On Windows the updater plugin exits the process without firing `RunEvent::Exit`, so the sidecar would otherwise survive and hold `drift-engine.exe` locked while NSIS tried to replace files in the install directory.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml` (27 passed), including a new test covering the installed and non-installed cases.

## UI changes

Not applicable. The About row that surfaces `update_support` ships with the About work in #37; this pull request only adds the command it calls.

## Checklist

- [x] The change is focused and does not include unrelated cleanup.
- [x] Tests cover new behavior or the reason tests are unnecessary is explained above.
- [x] Documentation is updated when behavior, configuration, or architecture changed.
- [x] No credentials, private data, build output, or local database files are included.
- [x] `engine/upstream/` was not edited directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for checking and installing application updates.
  - Updates are enabled only for installed copies, reducing prompts for local or portable builds.
  - Improved the update flow on Windows by stopping the running engine before installation and properly resuming it afterward.
- **Documentation**
  - Expanded the Updates section with clearer eligibility rules and the Windows install sequence.
- **Tests**
  - Added coverage for update eligibility based on whether the app is installed alongside the uninstaller.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->