### PR TITLE
fix: retry failed transcript loads

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -106,6 +106,15 @@ export function createActions(
     recordLinks(entries)
   }
 
+  function reportTranscriptFailure(id: string, cause: unknown) {
+    notice({
+      id: `transcript-load-${id}`,
+      title: "Transcript load failed",
+      message: sdkErrorMessage(cause, "Could not reach the engine"),
+      variant: "error",
+    })
+  }
+
   // Older pages come via the raw route because the generated SDK lacks the cursor param.
   async function loadOlder(id: string) {
     const cursor = state.cursors[id]
@@ -138,12 +147,7 @@ export function createActions(
     request = reloadSession(id)
       .then(() => true)
       .catch((cause) => {
-        notice({
-          id: `transcript-load-${id}`,
-          title: "Transcript load failed",
-          message: sdkErrorMessage(cause, "Could not reach the engine"),
-          variant: "error",
-        })
+        reportTranscriptFailure(id, cause)
         return false
       })
       .finally(() => {
@@ -712,7 +716,7 @@ export function createActions(
     }
     clearSessionError(id)
     if (result.data) putSession(set, result.data)
-    await reloadSession(id)
+    await reloadSession(id).catch((cause) => reportTranscriptFailure(id, cause))
     return true
   }
 
@@ -721,7 +725,7 @@ export function createActions(
     const result = await requireClient().session.unrevert({ path: { id } })
     if (!result.data) return false
     putSession(set, result.data)
-    await reloadSession(id)
+    await reloadSession(id).catch((cause) => reportTranscriptFailure(id, cause))
     return true
   }
 

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -75,6 +75,7 @@ export function createActions(
   const abortPollMs = 100
   const moveNoticeDurationMs = 8000
   let allSessionsRequest: Promise<void> | undefined
+  const transcriptRequests = new Map<string, Promise<boolean>>()
   const permissionReplies = new Map<string, Promise<boolean>>()
 
   // Writing `undefined` removes the key from the store. The non-null assertion is only there to
@@ -96,7 +97,9 @@ export function createActions(
 
   async function reloadSession(id: string) {
     const result = await requireClient().session.messages({ path: { id }, query: { limit: pageSize } })
-    const entries = [...(result.data ?? [])].sort((a, b) => a.info.id.localeCompare(b.info.id))
+    const entries = [...requireSdkData(result, "Could not load transcript")].sort((a, b) =>
+      a.info.id.localeCompare(b.info.id),
+    )
     set("transcripts", id, entries)
     set("loaded", id, true)
     set("cursors", id, result.response?.headers?.get("x-next-cursor") ?? null)
@@ -127,10 +130,27 @@ export function createActions(
     return sorted.length > 0
   }
 
-  async function openSession(id: string) {
-    if (state.loaded[id]) return
-    set("loaded", id, true)
-    await reloadSession(id)
+  function openSession(id: string) {
+    if (state.loaded[id]) return Promise.resolve(true)
+    const active = transcriptRequests.get(id)
+    if (active) return active
+    let request!: Promise<boolean>
+    request = reloadSession(id)
+      .then(() => true)
+      .catch((cause) => {
+        notice({
+          id: `transcript-load-${id}`,
+          title: "Transcript load failed",
+          message: sdkErrorMessage(cause, "Could not reach the engine"),
+          variant: "error",
+        })
+        return false
+      })
+      .finally(() => {
+        if (transcriptRequests.get(id) === request) transcriptRequests.delete(id)
+      })
+    transcriptRequests.set(id, request)
+    return request
   }
 
   async function loadSessions(directory: string) {

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -119,6 +119,7 @@ test("revert actions remain successful when their transcript refresh fails", asy
   )
 
   expect(await actions.revert("session", "message")).toBeTrue()
+  expect(state.notices.at(-1)?.message).toBe("refresh failed")
   expect(await actions.unrevert("session")).toBeTrue()
   expect(state.notices.at(-1)?.message).toBe("refresh failed")
 })

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import type { Message, Part } from "@opencode-ai/sdk/client"
+import type { Message, Part, Session } from "@opencode-ai/sdk/client"
 import { createActions } from "../src/engine/actions"
 import { createEngineState, type MessageEntry } from "../src/engine/store"
 
@@ -90,4 +90,35 @@ test("a successful empty transcript is authoritative", async () => {
   expect(state.loaded.session).toBeTrue()
   expect(state.transcripts.session).toEqual([])
   expect(state.cursors.session).toBeNull()
+})
+
+test("revert actions remain successful when their transcript refresh fails", async () => {
+  const session = {
+    id: "session",
+    slug: "session",
+    projectID: "project",
+    directory: "C:/work",
+    title: "Session",
+    version: "test",
+    time: { created: 1, updated: 1 },
+  } as Session
+  const [state, set] = createEngineState()
+  const actions = createActions(
+    () => ({
+      session: {
+        revert: async () => ({ data: session }),
+        unrevert: async () => ({ data: session }),
+        messages: async () => {
+          throw new Error("refresh failed")
+        },
+      },
+    }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+
+  expect(await actions.revert("session", "message")).toBeTrue()
+  expect(await actions.unrevert("session")).toBeTrue()
+  expect(state.notices.at(-1)?.message).toBe("refresh failed")
 })

--- a/tests/transcript-recovery.test.ts
+++ b/tests/transcript-recovery.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test"
+import type { Message, Part } from "@opencode-ai/sdk/client"
+import { createActions } from "../src/engine/actions"
+import { createEngineState, type MessageEntry } from "../src/engine/store"
+
+if (!("localStorage" in globalThis))
+  Object.defineProperty(globalThis, "localStorage", {
+    value: { getItem: () => null, setItem: () => undefined },
+  })
+
+function entry(id: string): MessageEntry {
+  return {
+    info: { id, sessionID: "session", role: "user", time: { created: 1 } } as Message,
+    parts: [{ id: `part-${id}`, sessionID: "session", messageID: id, type: "text", text: id } as Part],
+  }
+}
+
+function harness(messages: () => Promise<unknown>) {
+  const [state, set] = createEngineState()
+  const actions = createActions(
+    () => ({ session: { messages } }) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+  return { state, set, actions }
+}
+
+test("failed transcript loads preserve state and remain retryable", async () => {
+  let requests = 0
+  const fresh = entry("fresh")
+  const { state, set, actions } = harness(async () => {
+    requests += 1
+    if (requests === 1) throw new Error("network down")
+    return { data: [fresh], response: { headers: new Headers({ "x-next-cursor": "older" }) } }
+  })
+  const existing = entry("existing")
+  set("transcripts", "session", [existing])
+  set("cursors", "session", "keep")
+
+  expect(await actions.openSession("session")).toBeFalse()
+  expect(state.loaded.session).toBeUndefined()
+  expect(state.transcripts.session).toEqual([existing])
+  expect(state.cursors.session).toBe("keep")
+  expect(state.notices.at(-1)?.title).toBe("Transcript load failed")
+
+  expect(await actions.openSession("session")).toBeTrue()
+  expect(requests).toBe(2)
+  expect(state.loaded.session).toBeTrue()
+  expect(state.transcripts.session).toEqual([fresh])
+  expect(state.cursors.session).toBe("older")
+})
+
+test("SDK transcript errors do not replace existing data", async () => {
+  const existing = entry("existing")
+  const { state, set, actions } = harness(async () => ({ error: { message: "engine rejected the load" } }))
+  set("transcripts", "session", [existing])
+
+  expect(await actions.openSession("session")).toBeFalse()
+  expect(state.loaded.session).toBeUndefined()
+  expect(state.transcripts.session).toEqual([existing])
+  expect(state.notices.at(-1)?.message).toBe("engine rejected the load")
+})
+
+test("concurrent transcript opens share one request", async () => {
+  let requests = 0
+  let release!: () => void
+  const pending = new Promise<void>((resolve) => (release = resolve))
+  const { state, actions } = harness(async () => {
+    requests += 1
+    await pending
+    return { data: [entry("loaded")] }
+  })
+
+  const first = actions.openSession("session")
+  const second = actions.openSession("session")
+  expect(first).toBe(second)
+  expect(requests).toBe(1)
+  release()
+  expect(await Promise.all([first, second])).toEqual([true, true])
+  expect(state.loaded.session).toBeTrue()
+})
+
+test("a successful empty transcript is authoritative", async () => {
+  const { state, set, actions } = harness(async () => ({ data: [] }))
+  set("transcripts", "session", [entry("existing")])
+  set("cursors", "session", "keep")
+
+  expect(await actions.openSession("session")).toBeTrue()
+  expect(state.loaded.session).toBeTrue()
+  expect(state.transcripts.session).toEqual([])
+  expect(state.cursors.session).toBeNull()
+})


### PR DESCRIPTION
## Summary

- validate transcript responses before mutating loaded state
- preserve existing transcript and pagination data after failures
- coalesce concurrent opens and allow later retries
- report failed loads through a visible notice

## Verification

- `bun test tests/transcript-recovery.test.ts tests/startup.test.ts`
- `bun run typecheck`
- `git diff --check`

Fixes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript loading reliability when opening sessions.
  * Failed transcript loads now report errors without losing existing session state.
  * Retrying a failed load is supported.
  * Concurrent requests avoid duplicate transcript loading.
  * Empty transcripts now correctly replace stale data and reset cursors.
  * Revert and unrevert actions now remain stable and report transcript refresh failures instead of failing unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->