### PR TITLE
fix: preserve asks across polling failures

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -5,6 +5,8 @@ import { sleep, type EngineTarget } from "./connection"
 import { pushNotice } from "./events"
 import type { MessageEntry } from "./store"
 import {
+  askRevision,
+  bumpAskRevision,
   normalizeDir,
   putSession,
   putSessions,
@@ -74,9 +76,13 @@ export function createActions(
   const abortWaitMs = 5000
   const abortPollMs = 100
   const moveNoticeDurationMs = 8000
+  const askPollTimeoutMs = 8000
   let allSessionsRequest: Promise<void> | undefined
   const transcriptRequests = new Map<string, Promise<boolean>>()
   const permissionReplies = new Map<string, Promise<boolean>>()
+  const queuedAskDirectories = new Map<string, string>()
+  const activeAskDirectories = new Set<string>()
+  let askRefresh: Promise<void> | undefined
 
   // Writing `undefined` removes the key from the store. The non-null assertion is only there to
   // satisfy the setter's value type, which does not model deletion - it is not a real value.
@@ -554,71 +560,130 @@ export function createActions(
   // Replied ids are filtered out of poll snapshots that raced the reply.
   const answered = new Set<string>()
 
-  async function fetchJson<T>(path: string, dir: string): Promise<T | null> {
-    const base = target()
-    if (!base) return null
-    const response = await engineFetch(withDirectory(`${base.url}${path}`, dir), { headers: base.headers })
-    return response ? readJson<T | null>(response, null) : null
+  function askKey(kind: "permission" | "question", dir: string, id: string) {
+    return `${kind}\0${normalizeDir(dir)}\0${id}`
   }
 
-  // The generated SDK lags the engine here; GET /permission and /question recover asks
-  // raised while we weren't listening. Walk directories one at a time so idle workspaces
-  // don't stampede instance boots on a timer.
-  async function refreshPermissions(directories: string[]) {
-    if (!target() || directories.length === 0) return
-    const results: {
-      permissions: Permission[]
-      questions: QuestionRequest[]
-    }[] = []
-    for (const dir of directories) {
-      const [permissions, questions] = await Promise.all([
-        fetchJson<PermissionRequest[]>("/permission", dir),
-        fetchJson<QuestionRequest[]>("/question", dir),
-      ])
-      results.push({
-        permissions: (permissions ?? []).map((request) => toPermission(request, dir)),
-        questions: (questions ?? []).map((request) => ({ ...request, directory: dir })),
-      })
+  async function fetchAskSnapshot<T>(path: string, dir: string): Promise<{ ok: true; data: T[] } | { ok: false }> {
+    const base = target()
+    if (!base) return { ok: false }
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), askPollTimeoutMs)
+    try {
+      const response = await fetch(withDirectory(`${base.url}${path}`, dir), {
+        headers: base.headers,
+        signal: controller.signal,
+      }).catch(() => null)
+      if (!response?.ok) return { ok: false }
+      const data = await response.json().catch(() => null)
+      return Array.isArray(data) ? { ok: true, data: data as T[] } : { ok: false }
+    } finally {
+      clearTimeout(timeout)
     }
-    const keep = new Set(directories.map(normalizeDir))
-    const reported = new Set(results.flatMap((r) => [...r.permissions, ...r.questions].map((item) => item.id)))
-    const previous = new Set<string>()
-    for (const list of Object.values(state.permissions)) {
-      for (const item of list) {
-        const dir = item.metadata?.directory
-        if (typeof dir === "string" && keep.has(normalizeDir(dir))) previous.add(item.id)
-      }
+  }
+
+  function clearConfirmedAnswers(kind: "permission" | "question", dir: string, reported: Set<string>) {
+    const prefix = `${kind}\0${normalizeDir(dir)}\0`
+    for (const key of answered) {
+      if (!key.startsWith(prefix)) continue
+      if (!reported.has(key.slice(prefix.length))) answered.delete(key)
     }
-    for (const list of Object.values(state.questions)) {
-      for (const item of list) {
-        if (item.directory && keep.has(normalizeDir(item.directory))) previous.add(item.id)
-      }
-    }
-    for (const id of previous) if (!reported.has(id)) answered.delete(id)
+  }
+
+  function reconcilePermissions(dir: string, permissions: Permission[]) {
+    const reported = new Set(permissions.map((permission) => permission.id))
+    clearConfirmedAnswers("permission", dir, reported)
+    const normalized = normalizeDir(dir)
     set(
       produce((draft) => {
         for (const [sessionID, list] of Object.entries(draft.permissions)) {
-          draft.permissions[sessionID] = list.filter((item) => {
-            const dir = item.metadata?.directory
-            return typeof dir === "string" && !keep.has(normalizeDir(dir))
+          draft.permissions[sessionID] = list.filter((permission) => {
+            const directory = permission.metadata?.directory
+            return typeof directory !== "string" || normalizeDir(directory) !== normalized
           })
           if (!draft.permissions[sessionID]?.length) delete draft.permissions[sessionID]
         }
-        for (const [sessionID, list] of Object.entries(draft.questions)) {
-          draft.questions[sessionID] = list.filter((item) => {
-            const dir = item.directory
-            return typeof dir === "string" && !keep.has(normalizeDir(dir))
-          })
-          if (!draft.questions[sessionID]?.length) delete draft.questions[sessionID]
-        }
-        for (const result of results) {
-          for (const permission of result.permissions)
-            if (!answered.has(permission.id)) (draft.permissions[permission.sessionID] ??= []).push(permission)
-          for (const question of result.questions)
-            if (!answered.has(question.id)) (draft.questions[question.sessionID] ??= []).push(question)
+        for (const permission of permissions) {
+          if (answered.has(askKey("permission", dir, permission.id))) continue
+          const list = (draft.permissions[permission.sessionID] ??= [])
+          if (!list.some((current) => current.id === permission.id)) list.push(permission)
         }
       }),
     )
+  }
+
+  function reconcileQuestions(dir: string, questions: QuestionRequest[]) {
+    const reported = new Set(questions.map((question) => question.id))
+    clearConfirmedAnswers("question", dir, reported)
+    const normalized = normalizeDir(dir)
+    set(
+      produce((draft) => {
+        for (const [sessionID, list] of Object.entries(draft.questions)) {
+          draft.questions[sessionID] = list.filter(
+            (question) => !question.directory || normalizeDir(question.directory) !== normalized,
+          )
+          if (!draft.questions[sessionID]?.length) delete draft.questions[sessionID]
+        }
+        for (const question of questions) {
+          if (answered.has(askKey("question", dir, question.id))) continue
+          const list = (draft.questions[question.sessionID] ??= [])
+          if (!list.some((current) => current.id === question.id)) list.push(question)
+        }
+      }),
+    )
+  }
+
+  async function refreshDirectoryAsks(dir: string) {
+    const permissionRevision = askRevision(state, "permission", dir)
+    const questionRevision = askRevision(state, "question", dir)
+    const [permissionResult, questionResult] = await Promise.all([
+      fetchAskSnapshot<PermissionRequest>("/permission", dir),
+      fetchAskSnapshot<QuestionRequest>("/question", dir),
+    ])
+    if (permissionResult.ok && askRevision(state, "permission", dir) === permissionRevision) {
+      reconcilePermissions(
+        dir,
+        permissionResult.data.map((request) => toPermission(request, dir)),
+      )
+    }
+    if (questionResult.ok && askRevision(state, "question", dir) === questionRevision) {
+      reconcileQuestions(
+        dir,
+        questionResult.data.map((request) => ({ ...request, directory: dir })),
+      )
+    }
+  }
+
+  async function drainAskRefresh() {
+    while (queuedAskDirectories.size) {
+      const next = queuedAskDirectories.entries().next().value as [string, string]
+      queuedAskDirectories.delete(next[0])
+      activeAskDirectories.add(next[0])
+      try {
+        await refreshDirectoryAsks(next[1])
+      } finally {
+        activeAskDirectories.delete(next[0])
+      }
+    }
+  }
+
+  // The generated SDK lags the engine here; GET /permission and /question recover asks
+  // raised while we weren't listening. Polls are coalesced and directories are walked one
+  // at a time so idle workspaces do not stampede instance boots.
+  function refreshPermissions(directories: string[]) {
+    if (!target()) return Promise.resolve()
+    for (const dir of directories) {
+      const normalized = normalizeDir(dir)
+      if (!normalized || activeAskDirectories.has(normalized) || queuedAskDirectories.has(normalized)) continue
+      queuedAskDirectories.set(normalized, dir)
+    }
+    if (askRefresh) return askRefresh
+    let request!: Promise<void>
+    request = drainAskRefresh().finally(() => {
+      if (askRefresh === request) askRefresh = undefined
+    })
+    askRefresh = request
+    return request
   }
 
   function replyPermission(sessionID: string, permissionID: string, response: PermissionResponse) {
@@ -655,10 +720,12 @@ export function createActions(
         return failed()
       }
     }
-    answered.add(permissionID)
+    const answerDirectory = dir ?? state.directory
+    answered.add(askKey("permission", answerDirectory, permissionID))
     set(
       produce((draft) => {
         draft.permissions[sessionID] = (draft.permissions[sessionID] ?? []).filter((p) => p.id !== permissionID)
+        bumpAskRevision(draft, "permission", answerDirectory)
       }),
     )
     return true
@@ -677,10 +744,11 @@ export function createActions(
       body: JSON.stringify(answers ? { answers } : {}),
     })
     if (!response) return false
-    answered.add(requestID)
+    answered.add(askKey("question", dir, requestID))
     set(
       produce((draft) => {
         draft.questions[sessionID] = (draft.questions[sessionID] ?? []).filter((item) => item.id !== requestID)
+        bumpAskRevision(draft, "question", dir)
       }),
     )
     return true

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -3,7 +3,15 @@ import type { SetStoreFunction } from "solid-js/store"
 import { produce } from "solid-js/store"
 import { clearQuestionDraft } from "../state/question-drafts"
 import { errorText } from "./error"
-import { putSession, recordLink, spawnLink, type EngineState, type Notice, type QuestionRequest } from "./store"
+import {
+  bumpAskRevision,
+  putSession,
+  recordLink,
+  spawnLink,
+  type EngineState,
+  type Notice,
+  type QuestionRequest,
+} from "./store"
 
 type SetEngineState = SetStoreFunction<EngineState>
 
@@ -18,14 +26,15 @@ export function reduce(set: SetEngineState, event: Event, directory?: string) {
     raw.type === "question.replied" ||
     raw.type === "question.rejected"
   )
-    return dropQuestion(set, raw.properties.sessionID as string, raw.properties.requestID as string)
+    return dropQuestion(set, raw.properties.sessionID as string, raw.properties.requestID as string, directory)
   if (raw.type === "permission.asked" || raw.type === "permission.v2.asked")
-    return addPermission(set, permissionFromEvent(raw.properties, directory))
+    return addPermission(set, permissionFromEvent(raw.properties, directory), directory)
   if (raw.type === "permission.v2.replied" || raw.type === "permission.replied")
     return dropPermission(
       set,
       raw.properties.sessionID as string,
       (raw.properties.requestID ?? raw.properties.permissionID) as string,
+      directory,
     )
   if (raw.type === "tui.toast.show")
     return pushNotice(set, {
@@ -73,9 +82,9 @@ export function reduce(set: SetEngineState, event: Event, directory?: string) {
     case "message.part.removed":
       return dropPart(set, event.properties)
     case "permission.updated":
-      return addPermission(set, event.properties)
+      return addPermission(set, event.properties, directory)
     case "permission.replied":
-      return dropPermission(set, event.properties.sessionID, event.properties.permissionID)
+      return dropPermission(set, event.properties.sessionID, event.properties.permissionID, directory)
     case "todo.updated":
       return set("todos", event.properties.sessionID, event.properties.todos)
   }
@@ -230,6 +239,7 @@ function dropPart(set: SetEngineState, ref: { sessionID: string; messageID: stri
 function addQuestion(set: SetEngineState, question: QuestionRequest) {
   set(
     produce((draft) => {
+      bumpAskRevision(draft, "question", question.directory)
       const list = draft.questions[question.sessionID] ?? []
       if (!list.some((existing) => existing.id === question.id)) list.push(question)
       draft.questions[question.sessionID] = list
@@ -237,22 +247,31 @@ function addQuestion(set: SetEngineState, question: QuestionRequest) {
   )
 }
 
-function dropQuestion(set: SetEngineState, sessionID: string, requestID: string) {
+function dropQuestion(set: SetEngineState, sessionID: string, requestID: string, directory?: string) {
   clearQuestionDraft(requestID)
   set(
     produce((draft) => {
       const list = draft.questions[sessionID]
+      const current = list?.find((question) => question.id === requestID)
+      bumpAskRevision(draft, "question", current?.directory ?? directory)
       if (list) draft.questions[sessionID] = list.filter((question) => question.id !== requestID)
     }),
   )
 }
 
-function addPermission(set: SetEngineState, permission: Permission) {
+function addPermission(set: SetEngineState, permission: Permission, directory?: string) {
+  const resolvedDirectory =
+    typeof permission.metadata?.directory === "string" ? permission.metadata.directory : directory
+  const entry =
+    resolvedDirectory && !permission.metadata?.directory
+      ? { ...permission, metadata: { ...permission.metadata, directory: resolvedDirectory } }
+      : permission
   set(
     produce((draft) => {
-      const list = draft.permissions[permission.sessionID] ?? []
-      if (!list.some((existing) => existing.id === permission.id)) list.push(permission)
-      draft.permissions[permission.sessionID] = list
+      bumpAskRevision(draft, "permission", resolvedDirectory)
+      const list = draft.permissions[entry.sessionID] ?? []
+      if (!list.some((existing) => existing.id === entry.id)) list.push(entry)
+      draft.permissions[entry.sessionID] = list
     }),
   )
 }
@@ -276,10 +295,13 @@ function permissionFromEvent(properties: Record<string, unknown>, directory?: st
   }
 }
 
-function dropPermission(set: SetEngineState, sessionID: string, permissionID: string) {
+function dropPermission(set: SetEngineState, sessionID: string, permissionID: string, directory?: string) {
   set(
     produce((draft) => {
       const list = draft.permissions[sessionID]
+      const current = list?.find((permission) => permission.id === permissionID)
+      const currentDirectory = current?.metadata?.directory
+      bumpAskRevision(draft, "permission", typeof currentDirectory === "string" ? currentDirectory : directory)
       if (list) draft.permissions[sessionID] = list.filter((permission) => permission.id !== permissionID)
     }),
   )

--- a/src/engine/store.ts
+++ b/src/engine/store.ts
@@ -61,6 +61,8 @@ export type Notice = {
   duration: number
 }
 
+export type AskKind = "permission" | "question"
+
 export type EngineState = {
   connection: Connection
   directory: string
@@ -71,6 +73,7 @@ export type EngineState = {
   loaded: Record<string, boolean>
   permissions: Record<string, Permission[]>
   questions: Record<string, QuestionRequest[]>
+  askRevisions: Record<string, number>
   todos: Record<string, Todo[]>
   providers: ProviderInfo[]
   connected: string[]
@@ -116,6 +119,7 @@ export function createEngineState() {
     loaded: {},
     permissions: {},
     questions: {},
+    askRevisions: {},
     todos: {},
     providers: [],
     connected: [],
@@ -207,6 +211,20 @@ export function sessionBusy(state: EngineState, id: string) {
 
 export function normalizeDir(path: string) {
   return path.replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase()
+}
+
+export function askRevisionKey(kind: AskKind, directory: string) {
+  return `${kind}\0${normalizeDir(directory)}`
+}
+
+export function askRevision(state: EngineState, kind: AskKind, directory: string) {
+  return state.askRevisions[askRevisionKey(kind, directory)] ?? 0
+}
+
+export function bumpAskRevision(state: EngineState, kind: AskKind, directory?: string) {
+  if (!directory) return
+  const key = askRevisionKey(kind, directory)
+  state.askRevisions[key] = (state.askRevisions[key] ?? 0) + 1
 }
 
 export function sessionsFor(state: EngineState, directory: string) {

--- a/tests/permission-recovery.test.ts
+++ b/tests/permission-recovery.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, expect, test } from "bun:test"
+import type { Permission } from "@opencode-ai/sdk/client"
+import { createActions } from "../src/engine/actions"
+import { reduce } from "../src/engine/events"
+import { createEngineState, type QuestionRequest } from "../src/engine/store"
+
+if (!("localStorage" in globalThis))
+  Object.defineProperty(globalThis, "localStorage", {
+    value: { getItem: () => null, setItem: () => undefined },
+  })
+
+const originalFetch = globalThis.fetch
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+const home = "C:/work"
+const other = "C:/other"
+
+function permission(id: string, directory?: string): Permission {
+  return {
+    id,
+    type: "bash",
+    sessionID: "session",
+    messageID: "message",
+    title: id,
+    metadata: directory ? { directory } : {},
+    time: { created: 1 },
+  } as Permission
+}
+
+function question(id: string, directory?: string): QuestionRequest {
+  return { id, sessionID: "session", questions: [], ...(directory ? { directory } : {}) }
+}
+
+function harness() {
+  const [state, set] = createEngineState()
+  set("directory", home)
+  const actions = createActions(
+    () => ({}) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+  return { state, set, actions }
+}
+
+test("permission and question polling failures reconcile independently", async () => {
+  const { state, set, actions } = harness()
+  set("permissions", "session", [permission("permission", home)])
+  set("questions", "session", [question("question", home)])
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const path = new URL(String(input)).pathname
+    return path === "/permission" ? new Response("failed", { status: 500 }) : Response.json([])
+  }) as typeof fetch
+
+  await actions.refreshPermissions([home])
+  expect(state.permissions.session?.map((item) => item.id)).toEqual(["permission"])
+  expect(state.questions.session ?? []).toEqual([])
+
+  set("questions", "session", [question("question", home)])
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const path = new URL(String(input)).pathname
+    return path === "/question" ? new Response("failed", { status: 500 }) : Response.json([])
+  }) as typeof fetch
+
+  await actions.refreshPermissions([home])
+  expect(state.permissions.session ?? []).toEqual([])
+  expect(state.questions.session?.map((item) => item.id)).toEqual(["question"])
+})
+
+test("network and malformed polling responses preserve pending asks", async () => {
+  const { state, set, actions } = harness()
+  set("permissions", "session", [permission("permission", home)])
+  set("questions", "session", [question("question", home)])
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    if (new URL(String(input)).pathname === "/permission") throw new Error("offline")
+    return new Response("not-json", { status: 200 })
+  }) as typeof fetch
+
+  await actions.refreshPermissions([home])
+  expect(state.permissions.session?.map((item) => item.id)).toEqual(["permission"])
+  expect(state.questions.session?.map((item) => item.id)).toEqual(["question"])
+})
+
+test("successful scoped snapshots remove confirmed asks but preserve unknown and other directories", async () => {
+  const { state, set, actions } = harness()
+  set("permissions", "session", [permission("home", home), permission("unknown"), permission("other", other)])
+  set("questions", "session", [question("home", home), question("unknown"), question("other", other)])
+  globalThis.fetch = (async () => Response.json([])) as typeof fetch
+
+  await actions.refreshPermissions([home])
+  expect(state.permissions.session?.map((item) => item.id)).toEqual(["unknown", "other"])
+  expect(state.questions.session?.map((item) => item.id)).toEqual(["unknown", "other"])
+})
+
+test("new SSE asks survive an older empty polling snapshot", async () => {
+  const { state, set, actions } = harness()
+  const pending: ((response: Response) => void)[] = []
+  globalThis.fetch = (() => new Promise<Response>((resolve) => pending.push(resolve))) as typeof fetch
+
+  const refresh = actions.refreshPermissions([home])
+  reduce(
+    set,
+    {
+      type: "permission.asked",
+      properties: { id: "permission", sessionID: "session", permission: "bash", metadata: {} },
+    } as never,
+    home,
+  )
+  reduce(
+    set,
+    { type: "question.asked", properties: { id: "question", sessionID: "session", questions: [] } } as never,
+    home,
+  )
+  for (const resolve of pending) resolve(Response.json([]))
+  await refresh
+
+  expect(state.permissions.session?.map((item) => item.id)).toEqual(["permission"])
+  expect(state.questions.session?.map((item) => item.id)).toEqual(["question"])
+
+  globalThis.fetch = (async () => Response.json([])) as typeof fetch
+  await actions.refreshPermissions([home])
+  expect(state.permissions.session ?? []).toEqual([])
+  expect(state.questions.session ?? []).toEqual([])
+})
+
+test("a newer SSE reply is not resurrected by an older snapshot", async () => {
+  const { state, set, actions } = harness()
+  set("permissions", "session", [permission("permission", home)])
+  const pending: { path: string; resolve: (response: Response) => void }[] = []
+  globalThis.fetch = ((input: RequestInfo | URL) =>
+    new Promise<Response>((resolve) => pending.push({ path: new URL(String(input)).pathname, resolve }))) as typeof fetch
+
+  const refresh = actions.refreshPermissions([home])
+  reduce(
+    set,
+    { type: "permission.replied", properties: { sessionID: "session", permissionID: "permission" } } as never,
+    home,
+  )
+  for (const request of pending) {
+    request.resolve(
+      request.path === "/permission"
+        ? Response.json([{ id: "permission", sessionID: "session", permission: "bash", metadata: {} }])
+        : Response.json([]),
+    )
+  }
+  await refresh
+
+  expect(state.permissions.session ?? []).toEqual([])
+})
+
+test("overlapping polling sweeps coalesce active directories and drain new ones", async () => {
+  const { actions } = harness()
+  let releaseHome!: () => void
+  const homePending = new Promise<void>((resolve) => (releaseHome = resolve))
+  const requests: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input))
+    const directory = url.searchParams.get("directory") ?? ""
+    requests.push(`${directory}:${url.pathname}`)
+    if (directory === home) await homePending
+    return Response.json([])
+  }) as typeof fetch
+
+  const first = actions.refreshPermissions([home])
+  const second = actions.refreshPermissions([home, other])
+  expect(first).toBe(second)
+  releaseHome()
+  await Promise.all([first, second])
+
+  expect(requests.filter((request) => request.startsWith(`${home}:`))).toHaveLength(2)
+  expect(requests.filter((request) => request.startsWith(`${other}:`))).toHaveLength(2)
+})


### PR DESCRIPTION
## Summary

- preserve pending permissions and questions when polling fails or returns malformed data
- reconcile permission and question endpoints independently per directory
- prevent older HTTP snapshots from overwriting newer SSE asks or replies
- coalesce overlapping sweeps and bound each request with a timeout
- scope answered-request tombstones by kind and directory

## Verification

- `bun run test` (232 passed)
- `bun run typecheck`
- `git diff --check`

Fixes #9