### PR TITLE
fix: render abandoned tool calls as interrupted

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -1,12 +1,14 @@
 import { createOpencodeClient, type OpencodeClient, type Permission, type Session } from "@opencode-ai/sdk/client"
 import { createOpencodeClient as createControlClient } from "@opencode-ai/sdk/v2/client"
 import { produce, type SetStoreFunction } from "solid-js/store"
+import { t } from "../state/i18n"
 import { sleep, type EngineTarget } from "./connection"
 import { pushNotice } from "./events"
 import type { MessageEntry } from "./store"
 import {
   askRevision,
   bumpAskRevision,
+  interruptStaleTools,
   normalizeDir,
   putSession,
   putSessions,
@@ -103,8 +105,10 @@ export function createActions(
 
   async function reloadSession(id: string) {
     const result = await requireClient().session.messages({ path: { id }, query: { limit: pageSize } })
-    const entries = [...requireSdkData(result, "Could not load transcript")].sort((a, b) =>
-      a.info.id.localeCompare(b.info.id),
+    const entries = interruptStaleTools(
+      [...requireSdkData(result, "Could not load transcript")].sort((a, b) => a.info.id.localeCompare(b.info.id)),
+      state.liveTools,
+      t("drift.message.interrupted"),
     )
     set("transcripts", id, entries)
     set("loaded", id, true)
@@ -132,7 +136,11 @@ export function createActions(
     const response = await engineFetch(url, { headers: base.headers })
     if (!response) return false
     const older = await readJson<MessageEntry[]>(response, [])
-    const sorted = [...older].sort((a, b) => a.info.id.localeCompare(b.info.id))
+    const sorted = interruptStaleTools(
+      [...older].sort((a, b) => a.info.id.localeCompare(b.info.id)),
+      state.liveTools,
+      t("drift.message.interrupted"),
+    )
     set(
       produce((draft) => {
         const existing = new Set((draft.transcripts[id] ?? []).map((entry) => entry.info.id))
@@ -448,6 +456,7 @@ export function createActions(
       if (!control) return false
       const result = await control.global.dispose().catch(() => null)
       if (result?.data !== true) return false
+      set("liveTools", {})
       await sleep(disposeSettleMs)
       return true
     }
@@ -553,6 +562,8 @@ export function createActions(
         delete draft.sessions[id]
         delete draft.transcripts[id]
         delete draft.loaded[id]
+        for (const [partID, owner] of Object.entries(draft.liveTools))
+          if (owner === id) delete draft.liveTools[partID]
       }),
     )
   }

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -65,12 +65,24 @@ export function reduce(set: SetEngineState, event: Event, directory?: string) {
       return upsertSession(set, event.properties.info)
     case "session.deleted":
       return dropSession(set, event.properties.info)
-    case "session.status":
-      set("status", event.properties.sessionID, event.properties.status)
+    case "session.status": {
+      const sessionID = event.properties.sessionID
+      set(
+        produce((draft) => {
+          draft.status[sessionID] = event.properties.status
+          if (event.properties.status.type === "idle") clearLiveTools(draft, sessionID)
+        }),
+      )
       if (event.properties.status.type !== "idle") clearError(set, event.properties.sessionID)
       return
+    }
     case "session.idle":
-      return set("status", event.properties.sessionID, { type: "idle" })
+      return set(
+        produce((draft) => {
+          draft.status[event.properties.sessionID] = { type: "idle" }
+          clearLiveTools(draft, event.properties.sessionID)
+        }),
+      )
     case "session.error":
       return recordError(set, event.properties.sessionID, event.properties.error)
     case "message.updated":
@@ -108,8 +120,13 @@ function dropSession(set: SetEngineState, info: Session) {
       delete draft.status[info.id]
       delete draft.activity[info.id]
       delete draft.errors[info.id]
+      clearLiveTools(draft, info.id)
     }),
   )
+}
+
+function clearLiveTools(draft: EngineState, sessionID: string) {
+  for (const [partID, owner] of Object.entries(draft.liveTools)) if (owner === sessionID) delete draft.liveTools[partID]
 }
 
 function moveSession(
@@ -150,6 +167,7 @@ function recordError(set: SetEngineState, sessionID?: string, error?: { name: st
     produce((draft) => {
       draft.status[sessionID] = { type: "idle" }
       if (draft.activity[sessionID]) draft.activity[sessionID].current = undefined
+      clearLiveTools(draft, sessionID)
       if (error?.name === "MessageAbortedError") return
       draft.errors[sessionID] = message
     }),
@@ -191,7 +209,11 @@ function upsertPart(set: SetEngineState, part: Part) {
   set(
     produce((draft) => {
       if (link) draft.links[link.child] = link.parent
-      if (part.type === "tool") trackActivity(draft, part)
+      if (part.type === "tool") {
+        trackActivity(draft, part)
+        if (part.state.status === "pending" || part.state.status === "running") draft.liveTools[part.id] = part.sessionID
+        else delete draft.liveTools[part.id]
+      }
       const entry = draft.transcripts[part.sessionID]?.find((item) => item.info.id === part.messageID)
       if (!entry) return
       const index = entry.parts.findIndex((existing) => existing.id === part.id)
@@ -232,6 +254,7 @@ function dropPart(set: SetEngineState, ref: { sessionID: string; messageID: stri
     produce((draft) => {
       const entry = draft.transcripts[ref.sessionID]?.find((item) => item.info.id === ref.messageID)
       if (entry) entry.parts = entry.parts.filter((part) => part.id !== ref.partID)
+      delete draft.liveTools[ref.partID]
     }),
   )
 }

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -2,12 +2,13 @@ import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/clie
 import { createContext, onCleanup, useContext, type ParentProps } from "solid-js"
 import { produce } from "solid-js/store"
 import { shellEvents } from "../shell"
+import { t } from "../state/i18n"
 import { createActions, type EngineActions } from "./actions"
 import { inspectShellEngine, resolveEngine, restartShellEngine, sleep, type EngineTarget } from "./connection"
 import { reduce } from "./events"
 import { streamEvents } from "./sse"
 import { seedBench } from "./bench"
-import { createEngineState, putSessions, type EngineState, type ProviderInfo } from "./store"
+import { createEngineState, interruptStaleTools, putSessions, type EngineState, type ProviderInfo } from "./store"
 
 export type Engine = {
   state: EngineState
@@ -63,7 +64,13 @@ export function EngineProvider(props: ParentProps) {
       set(
         produce((draft) => {
           const live = statuses.data ?? {}
-          for (const session of sessions.data ?? []) draft.status[session.id] = live[session.id] ?? { type: "idle" }
+          for (const session of sessions.data ?? []) {
+            const status = live[session.id] ?? { type: "idle" as const }
+            draft.status[session.id] = status
+            if (status.type === "idle")
+              for (const [partID, owner] of Object.entries(draft.liveTools))
+                if (owner === session.id) delete draft.liveTools[partID]
+          }
         }),
       )
       set("providers", (providers.data?.all ?? []) as unknown as ProviderInfo[])
@@ -77,7 +84,8 @@ export function EngineProvider(props: ParentProps) {
       if (!current()) return
       for (const [id, result] of transcripts) {
         if (!result.data) continue
-        set("transcripts", id, [...result.data].sort((a, b) => a.info.id.localeCompare(b.info.id)))
+        const entries = [...result.data].sort((a, b) => a.info.id.localeCompare(b.info.id))
+        set("transcripts", id, interruptStaleTools(entries, state.liveTools, t("drift.message.interrupted")))
         set("cursors", id, result.response?.headers?.get("x-next-cursor") ?? null)
       }
       if (!state.version && base) {
@@ -104,6 +112,7 @@ export function EngineProvider(props: ParentProps) {
         draft.engineError = message
         draft.engineRestarting = false
         draft.connection = directory ? "offline" : "idle"
+        draft.liveTools = {}
       }),
     )
   }
@@ -179,6 +188,7 @@ export function EngineProvider(props: ParentProps) {
       produce((draft) => {
         draft.engineRestarting = true
         draft.connection = directory ? "connecting" : "idle"
+        draft.liveTools = {}
       }),
     )
     let request!: Promise<boolean>

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -127,6 +127,7 @@ export function EngineProvider(props: ParentProps) {
     }
     if (status.target && !sameTarget(base, status.target)) {
       base = status.target
+      set("liveTools", {})
       if (directory) client = createOpencodeClient({ baseUrl: base.url, headers: base.headers, directory })
     }
     return false

--- a/src/engine/store.ts
+++ b/src/engine/store.ts
@@ -8,6 +8,7 @@ import type {
   Session,
   SessionStatus,
   Todo,
+  ToolPart,
 } from "@opencode-ai/sdk/client"
 import { createStore, produce, type SetStoreFunction } from "solid-js/store"
 import type { Connection } from "./connection"
@@ -16,6 +17,31 @@ export type ModelInfo = Model & { family?: string; release_date?: string; varian
 export type ProviderInfo = { id: string; name: string; models: Record<string, ModelInfo> }
 export type ModelRef = { providerID: string; modelID: string }
 export type MessageEntry = { info: Message; parts: Part[] }
+
+export function interruptStaleTools(entries: MessageEntry[], liveTools: Readonly<Record<string, string>>, error = "Interrupted") {
+  return entries.map((entry) => {
+    let changed = false
+    const parts = entry.parts.map((part) => {
+      if (part.type !== "tool" || (part.state.status !== "pending" && part.state.status !== "running")) return part
+      if (liveTools[part.id] === part.sessionID) return part
+      changed = true
+      const completed = (entry.info as { time: { completed?: number } }).time.completed
+      const start = "time" in part.state ? part.state.time.start : entry.info.time.created
+      const metadata = "metadata" in part.state ? part.state.metadata : undefined
+      return {
+        ...part,
+        state: {
+          status: "error",
+          input: part.state.input,
+          error,
+          metadata,
+          time: { start, end: Math.max(start, completed ?? start) },
+        },
+      } as ToolPart
+    })
+    return changed ? { ...entry, parts } : entry
+  })
+}
 
 export function messageText(entry: MessageEntry) {
   return entry.parts
@@ -84,6 +110,7 @@ export type EngineState = {
   notices: Notice[]
   links: Record<string, string>
   activity: Record<string, SessionActivity>
+  liveTools: Record<string, string>
   cursors: Record<string, string | null>
   version: string
   startupError: string
@@ -132,6 +159,7 @@ export function createEngineState() {
     notices: [],
     links: { ...loadLinks() },
     activity: {},
+    liveTools: {},
     startupError: "",
     engineError: "",
     engineRestarting: false,

--- a/tests/activity.test.ts
+++ b/tests/activity.test.ts
@@ -238,6 +238,51 @@ test("compaction-only user messages retain their delimiter part", async () => {
   expect(compactionParts(entry).map((part) => part.id)).toEqual(["p1"])
 })
 
+test("loaded stale tool states become interrupted without mutating live or completed parts", async () => {
+  const { interruptStaleTools } = await import("../src/engine/store")
+  const tool = (id: string, status: "pending" | "running" | "completed", messageID = "a1") =>
+    ({
+      id,
+      sessionID: "s1",
+      messageID,
+      type: "tool",
+      callID: id,
+      tool: "bash",
+      state:
+        status === "pending"
+          ? { status, input: {}, raw: "" }
+          : status === "running"
+          ? { status, input: {}, time: { start: 2 } }
+          : { status, input: {}, output: "ok", title: "", metadata: {}, time: { start: 2, end: 3 } },
+    }) as never
+  const entry = {
+    info: { id: "a1", sessionID: "s1", role: "assistant", time: { created: 1 } },
+    parts: [tool("stale", "running"), tool("pending", "pending"), tool("done", "completed")],
+  } as never
+
+  expect(interruptStaleTools([entry], { stale: "s1", pending: "s1" }, "Interrupted")[0]).toBe(entry)
+  const interrupted = interruptStaleTools([entry], {}, "Interrupted")[0]
+  expect((interrupted.parts[0] as { state: { status: string; error: string } }).state).toMatchObject({
+    status: "error",
+    error: "Interrupted",
+  })
+  expect((interrupted.parts[1] as { state: { status: string; error: string } }).state).toMatchObject({
+    status: "error",
+    error: "Interrupted",
+  })
+  expect((interrupted.parts[2] as { state: { status: string } }).state.status).toBe("completed")
+  expect((entry.parts[0] as { state: { status: string } }).state.status).toBe("running")
+
+  const old = entry
+  const live = {
+    info: { id: "a2", sessionID: "s1", role: "assistant", time: { created: 4 } },
+    parts: [tool("live", "running", "a2")],
+  } as never
+  const duringTurn = interruptStaleTools([old, live], { live: "s1" }, "Interrupted")
+  expect((duringTurn[0].parts[0] as { state: { status: string } }).state.status).toBe("error")
+  expect((duringTurn[1].parts[0] as { state: { status: string } }).state.status).toBe("running")
+})
+
 test("streamed tool replacements retain mounted group and plugin identities", async () => {
   const { groupParts, updatePartGroupSlots } = await import("../src/ui/message")
   // Bun selects Solid's server condition for tests, so load the browser primitives
@@ -676,20 +721,29 @@ test("context usage skips a trailing zero-token assistant message", async () => 
 test("activity counts distinct tool parts and tracks the running tool", () => {
   const [state, set] = createEngineState()
   reduce(set, toolEvent("p1", "grep", "running"))
+  expect(state.liveTools.p1).toBe("child")
   reduce(set, toolEvent("p1", "grep", "completed"))
+  expect(state.liveTools.p1).toBeUndefined()
   reduce(set, toolEvent("p2", "read", "pending"))
   reduce(set, toolEvent("p2", "read", "running"))
+  expect(state.liveTools.p2).toBe("child")
   expect(state.activity["child"].tools).toBe(2)
   expect(state.activity["child"].current).toBe("read")
   reduce(set, toolEvent("p2", "read", "completed"))
+  expect(state.liveTools.p2).toBeUndefined()
   expect(state.activity["child"].tools).toBe(2)
   expect(state.activity["child"].current).toBeUndefined()
+
+  reduce(set, toolEvent("p3", "bash", "running"))
+  reduce(set, { type: "session.idle", properties: { sessionID: "child" } } as never)
+  expect(state.liveTools.p3).toBeUndefined()
 })
 
 test("session errors terminate busy activity and remain visible", () => {
   const [state, set] = createEngineState()
   set("status", "s1", { type: "busy" })
   set("activity", "s1", { tools: 1, lastPartId: "p1", current: "bash" })
+  set("liveTools", "p1", "s1")
   reduce(
     set,
     {
@@ -699,6 +753,7 @@ test("session errors terminate busy activity and remain visible", () => {
   )
   expect(state.status["s1"].type).toBe("idle")
   expect(state.activity["s1"].current).toBeUndefined()
+  expect(state.liveTools.p1).toBeUndefined()
   expect(state.errors["s1"]).toBe("credit balance is too low")
 })
 


### PR DESCRIPTION
## Summary
- track tool calls observed live on the current event stream
- convert persisted pending or running tool rows without live evidence into localized interrupted errors
- clear live evidence on idle, error, engine replacement, disposal, and session cleanup
- normalize initial, refreshed, and paginated transcripts through the same path

## Testing
- bun run typecheck
- bun run test
- bun run build
- git diff --check

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted or stale tool activity after reloads, transcript restoration, and older-page loading.
  * Cleared tool activity when sessions become idle, fail, restart, or are deleted.
  * Preserved completed tool activity while removing inactive or obsolete entries.

* **Tests**
  * Added coverage for stale tool interruption, activity tracking, completion, idle sessions, and session errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->