### PR TITLE
fix: suppress auto-approved permission attention

### DIFF
--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -2,6 +2,15 @@ import { createOpencodeClient, type OpencodeClient, type Permission, type Sessio
 import { createOpencodeClient as createControlClient } from "@opencode-ai/sdk/v2/client"
 import { produce, type SetStoreFunction } from "solid-js/store"
 import { t } from "../state/i18n"
+import {
+  beginPermissionReply,
+  clearPermissionAttention,
+  clearPermissionAttentionFor,
+  failPermissionReply,
+  observePermission,
+  prunePermissionAttention,
+  type DriftPermission,
+} from "../state/permission-attention"
 import { sleep, type EngineTarget } from "./connection"
 import { pushNotice } from "./events"
 import type { MessageEntry } from "./store"
@@ -39,6 +48,7 @@ type PermissionRequest = {
   sessionID: string
   permission: string
   patterns?: string[]
+  always?: string[]
   metadata?: Record<string, unknown>
   tool?: { messageID: string; callID: string }
 }
@@ -52,7 +62,7 @@ function toPermission(request: PermissionRequest, directory: string): Permission
     messageID: request.tool?.messageID ?? "",
     callID: request.tool?.callID,
     title: String(request.metadata?.title ?? request.permission),
-    metadata: { ...request.metadata, directory },
+    metadata: { ...request.metadata, ...(request.always ? { always: request.always } : {}), directory },
     time: { created: Date.now() },
   }
 }
@@ -79,6 +89,7 @@ export function createActions(
   const abortPollMs = 100
   const moveNoticeDurationMs = 8000
   const askPollTimeoutMs = 8000
+  const permissionReplyTimeoutMs = 8000
   let allSessionsRequest: Promise<void> | undefined
   const transcriptRequests = new Map<string, Promise<boolean>>()
   const permissionReplies = new Map<string, Promise<boolean>>()
@@ -456,6 +467,7 @@ export function createActions(
       if (!control) return false
       const result = await control.global.dispose().catch(() => null)
       if (result?.data !== true) return false
+      clearPermissionAttentionFor(Object.values(state.permissions).flat())
       set("liveTools", {})
       await sleep(disposeSettleMs)
       return true
@@ -557,6 +569,7 @@ export function createActions(
   // clears permissions, questions, todos, status, activity and errors. The two have never agreed;
   // whether this one is missing those deletes has not been established.
   function forgetSession(id: string) {
+    clearPermissionAttentionFor(state.permissions[id] ?? [])
     set(
       produce((draft) => {
         delete draft.sessions[id]
@@ -605,10 +618,12 @@ export function createActions(
     const reported = new Set(permissions.map((permission) => permission.id))
     clearConfirmedAnswers("permission", dir, reported)
     const normalized = normalizeDir(dir)
+    for (const permission of permissions) observePermission(permission, state)
     set(
       produce((draft) => {
         for (const [sessionID, list] of Object.entries(draft.permissions)) {
           draft.permissions[sessionID] = list.filter((permission) => {
+            if ((permission as DriftPermission).driftProtocol === "v2") return true
             const directory = permission.metadata?.directory
             return typeof directory !== "string" || normalizeDir(directory) !== normalized
           })
@@ -621,6 +636,7 @@ export function createActions(
         }
       }),
     )
+    prunePermissionAttention(new Set(Object.values(state.permissions).flat().map((permission) => permission.id)))
   }
 
   function reconcileQuestions(dir: string, questions: QuestionRequest[]) {
@@ -708,30 +724,16 @@ export function createActions(
 
   async function sendPermissionReply(sessionID: string, permissionID: string, response: PermissionResponse) {
     const permission = (state.permissions[sessionID] ?? []).find((p) => p.id === permissionID)
+    if (permission) beginPermissionReply(permission, response, Object.values(state.permissions).flat())
     const dir = permission?.metadata?.directory as string | undefined
     const failed = () => {
+      failPermissionReply(permissionID)
       const message = "The request is still pending. Try again."
       notice({ title: "Permission reply failed", message, variant: "error" })
       return false
     }
-    if (dir && normalizeDir(dir) !== normalizeDir(state.directory)) {
-      // A swallowed failure would hide the card while the engine stays blocked on the ask, and
-      // because the card is gone poll reconciliation never clears it from `answered`.
-      if (!(await replyElsewhere(sessionID, permissionID, response, dir))) return failed()
-    } else {
-      // requireClient() throws while offline and the request itself can reject. UI callers
-      // fire-and-forget this action, so both must resolve to a visible failure.
-      try {
-        const result = await requireClient().postSessionIdPermissionsPermissionId({
-          path: { id: sessionID, permissionID },
-          body: { response },
-        })
-        if (result.error) return failed()
-      } catch {
-        return failed()
-      }
-    }
     const answerDirectory = dir ?? state.directory
+    if (!(await postPermissionReply(permission, sessionID, permissionID, response, answerDirectory))) return failed()
     answered.add(askKey("permission", answerDirectory, permissionID))
     set(
       produce((draft) => {
@@ -739,6 +741,7 @@ export function createActions(
         bumpAskRevision(draft, "permission", answerDirectory)
       }),
     )
+    clearPermissionAttention(permissionID)
     return true
   }
 
@@ -765,16 +768,33 @@ export function createActions(
     return true
   }
 
-  async function replyElsewhere(sessionID: string, permissionID: string, response: PermissionResponse, dir: string) {
+  async function postPermissionReply(
+    permission: Permission | undefined,
+    sessionID: string,
+    permissionID: string,
+    response: PermissionResponse,
+    dir: string,
+  ) {
     const base = target()
     if (!base) return false
-    const url = withDirectory(`${base.url}/session/${sessionID}/permissions/${permissionID}`, dir)
-    const result = await engineFetch(url, {
-      method: "POST",
-      headers: jsonHeaders(base),
-      body: JSON.stringify({ response }),
-    })
-    return result !== null
+    const v2 = (permission as DriftPermission | undefined)?.driftProtocol === "v2"
+    const path = v2
+      ? `/api/session/${sessionID}/permission/${permissionID}/reply`
+      : `/session/${sessionID}/permissions/${permissionID}`
+    const url = withDirectory(`${base.url}${path}`, dir)
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), permissionReplyTimeoutMs)
+    try {
+      const result = await engineFetch(url, {
+        method: "POST",
+        headers: jsonHeaders(base),
+        body: JSON.stringify(v2 ? { reply: response } : { response }),
+        signal: controller.signal,
+      })
+      return result !== null
+    } finally {
+      clearTimeout(timeout)
+    }
   }
 
   async function interrupt(id: string) {

--- a/src/engine/actions.ts
+++ b/src/engine/actions.ts
@@ -564,10 +564,6 @@ export function createActions(
     forgetSession(id)
   }
 
-  // Drops only the transcript-shaped state for a session we deleted ourselves.
-  // NOTE: events.ts dropSession, which handles the engine's own session-deleted event, additionally
-  // clears permissions, questions, todos, status, activity and errors. The two have never agreed;
-  // whether this one is missing those deletes has not been established.
   function forgetSession(id: string) {
     clearPermissionAttentionFor(state.permissions[id] ?? [])
     set(
@@ -575,6 +571,13 @@ export function createActions(
         delete draft.sessions[id]
         delete draft.transcripts[id]
         delete draft.loaded[id]
+        delete draft.permissions[id]
+        delete draft.questions[id]
+        delete draft.todos[id]
+        delete draft.status[id]
+        delete draft.activity[id]
+        delete draft.errors[id]
+        delete draft.cursors[id]
         for (const [partID, owner] of Object.entries(draft.liveTools))
           if (owner === id) delete draft.liveTools[partID]
       }),

--- a/src/engine/events.ts
+++ b/src/engine/events.ts
@@ -2,6 +2,12 @@ import type { Event, Message, Part, Permission, Session } from "@opencode-ai/sdk
 import type { SetStoreFunction } from "solid-js/store"
 import { produce } from "solid-js/store"
 import { clearQuestionDraft } from "../state/question-drafts"
+import {
+  clearPermissionAttention,
+  clearPermissionAttentionFor,
+  observePermission,
+  type DriftPermission,
+} from "../state/permission-attention"
 import { errorText } from "./error"
 import {
   bumpAskRevision,
@@ -15,7 +21,7 @@ import {
 
 type SetEngineState = SetStoreFunction<EngineState>
 
-export function reduce(set: SetEngineState, event: Event, directory?: string) {
+export function reduce(set: SetEngineState, event: Event, directory?: string, state?: EngineState) {
   // These events are newer than the generated v1 SDK's Event union.
   const raw = event as { id?: string; type: string; properties: Record<string, unknown> }
   if (raw.type === "question.v2.asked" || raw.type === "question.asked")
@@ -28,7 +34,12 @@ export function reduce(set: SetEngineState, event: Event, directory?: string) {
   )
     return dropQuestion(set, raw.properties.sessionID as string, raw.properties.requestID as string, directory)
   if (raw.type === "permission.asked" || raw.type === "permission.v2.asked")
-    return addPermission(set, permissionFromEvent(raw.properties, directory), directory)
+    return addPermission(
+      set,
+      permissionFromEvent(raw.properties, directory, raw.type === "permission.v2.asked"),
+      directory,
+      state,
+    )
   if (raw.type === "permission.v2.replied" || raw.type === "permission.replied")
     return dropPermission(
       set,
@@ -94,7 +105,7 @@ export function reduce(set: SetEngineState, event: Event, directory?: string) {
     case "message.part.removed":
       return dropPart(set, event.properties)
     case "permission.updated":
-      return addPermission(set, event.properties, directory)
+      return addPermission(set, event.properties, directory, state)
     case "permission.replied":
       return dropPermission(set, event.properties.sessionID, event.properties.permissionID, directory)
     case "todo.updated":
@@ -111,6 +122,7 @@ function upsertSession(set: SetEngineState, info: Session) {
 function dropSession(set: SetEngineState, info: Session) {
   set(
     produce((draft) => {
+      clearPermissionAttentionFor(draft.permissions[info.id] ?? [])
       delete draft.sessions[info.id]
       delete draft.transcripts[info.id]
       delete draft.loaded[info.id]
@@ -282,13 +294,14 @@ function dropQuestion(set: SetEngineState, sessionID: string, requestID: string,
   )
 }
 
-function addPermission(set: SetEngineState, permission: Permission, directory?: string) {
+function addPermission(set: SetEngineState, permission: Permission, directory?: string, state?: EngineState) {
   const resolvedDirectory =
     typeof permission.metadata?.directory === "string" ? permission.metadata.directory : directory
   const entry =
     resolvedDirectory && !permission.metadata?.directory
       ? { ...permission, metadata: { ...permission.metadata, directory: resolvedDirectory } }
       : permission
+  observePermission(entry, state)
   set(
     produce((draft) => {
       bumpAskRevision(draft, "permission", resolvedDirectory)
@@ -299,12 +312,13 @@ function addPermission(set: SetEngineState, permission: Permission, directory?: 
   )
 }
 
-function permissionFromEvent(properties: Record<string, unknown>, directory?: string): Permission {
+function permissionFromEvent(properties: Record<string, unknown>, directory?: string, v2 = false): DriftPermission {
   const source = properties.source as { messageID?: string; callID?: string } | undefined
   const tool = properties.tool as { messageID?: string; callID?: string } | undefined
   const metadata = (properties.metadata as Record<string, unknown> | undefined) ?? {}
   const type = String(properties.permission ?? properties.action ?? "permission")
   const patterns = properties.patterns ?? properties.resources
+  const always = v2 ? properties.save : properties.always
   return {
     id: String(properties.id),
     type,
@@ -313,12 +327,18 @@ function permissionFromEvent(properties: Record<string, unknown>, directory?: st
     messageID: tool?.messageID ?? source?.messageID ?? "",
     callID: tool?.callID ?? source?.callID,
     title: String(metadata.title ?? type),
-    metadata: directory ? { ...metadata, directory } : metadata,
+    metadata: {
+      ...metadata,
+      ...(Array.isArray(always) ? { always: always.map(String) } : {}),
+      ...(directory ? { directory } : {}),
+    },
     time: { created: Date.now() },
+    ...(v2 ? { driftProtocol: "v2" as const } : {}),
   }
 }
 
 function dropPermission(set: SetEngineState, sessionID: string, permissionID: string, directory?: string) {
+  clearPermissionAttention(permissionID)
   set(
     produce((draft) => {
       const list = draft.permissions[sessionID]

--- a/src/engine/index.tsx
+++ b/src/engine/index.tsx
@@ -3,6 +3,7 @@ import { createContext, onCleanup, useContext, type ParentProps } from "solid-js
 import { produce } from "solid-js/store"
 import { shellEvents } from "../shell"
 import { t } from "../state/i18n"
+import { clearPermissionAttentionFor } from "../state/permission-attention"
 import { createActions, type EngineActions } from "./actions"
 import { inspectShellEngine, resolveEngine, restartShellEngine, sleep, type EngineTarget } from "./connection"
 import { reduce } from "./events"
@@ -144,7 +145,7 @@ export function EngineProvider(props: ParentProps) {
             void hydrate().catch(() => undefined)
             return
           }
-          reduce(set, event, eventDirectory)
+          reduce(set, event, eventDirectory, state)
         })
       } catch {}
       if (signal.aborted) return
@@ -280,6 +281,7 @@ export function EngineProvider(props: ParentProps) {
     disposed = true
     pumpAbort?.abort()
     unlistenEngineExit?.()
+    clearPermissionAttentionFor(Object.values(state.permissions).flat())
   })
 
   return <EngineContext.Provider value={{ state, actions, setDirectory, restartEngine }}>{props.children}</EngineContext.Provider>

--- a/src/state/permission-attention.ts
+++ b/src/state/permission-attention.ts
@@ -1,0 +1,178 @@
+import type { Permission } from "@opencode-ai/sdk/client"
+import { createSignal } from "solid-js"
+import type { EngineState } from "../engine/store"
+import { autoAcceptAllowed, autoAcceptGlobal, autoAcceptSessions } from "./prefs"
+
+type Marker = { kind: "replying" | "settling" | "failed"; token: number }
+type Policy = { global: boolean; sessions: string[] }
+export type DriftPermission = Permission & { driftProtocol?: "v2" }
+type AlwaysRule = {
+  protocol: "v1" | "v2"
+  sessionID: string
+  directory: string
+  type: string
+  patterns: string[]
+  expires: number
+}
+
+const settleMs = 350
+const lineageSettleMs = 500
+const replyWatchdogMs = 8000
+let sequence = 0
+let alwaysRules: AlwaysRule[] = []
+const [markers, setMarkers] = createSignal<Record<string, Marker>>({})
+
+function policyAllowed(permission: Permission, state: EngineState, policy?: Policy) {
+  return autoAcceptAllowed(
+    policy?.global ?? autoAcceptGlobal(),
+    policy?.sessions ?? autoAcceptSessions(),
+    permission.sessionID,
+    state.sessions[permission.sessionID]?.parentID,
+    state.links[permission.sessionID],
+  )
+}
+
+export function permissionRequiresAttention(permission: Permission, state: EngineState, policy?: Policy) {
+  const marker = markers()[permission.id]
+  if (marker?.kind === "failed") return true
+  if (marker) return false
+  return !policyAllowed(permission, state, policy)
+}
+
+export function permissionShouldAutoReply(permission: Permission, state: EngineState) {
+  return !markers()[permission.id] && policyAllowed(permission, state)
+}
+
+function setMarker(id: string, kind: Marker["kind"], timeout?: number) {
+  const marker = { kind, token: ++sequence } as const
+  setMarkers((current) => ({ ...current, [id]: marker }))
+  if (timeout)
+    setTimeout(() => {
+      setMarkers((current) => {
+        if (current[id]?.token !== marker.token) return current
+        return { ...current, [id]: { kind: "failed", token: ++sequence } }
+      })
+    }, timeout)
+  return marker
+}
+
+function settle(permission: Permission, timeout = settleMs) {
+  const marker = setMarker(permission.id, "settling")
+  setTimeout(() => {
+    setMarkers((current) => {
+      if (current[permission.id]?.token !== marker.token) return current
+      const next = { ...current }
+      delete next[permission.id]
+      return next
+    })
+  }, timeout)
+}
+
+function related(rule: AlwaysRule, permission: Permission) {
+  const requested = requestPatterns(permission)
+  const protocol = (permission as DriftPermission).driftProtocol === "v2" ? "v2" : "v1"
+  const patternsMatch = requested.length
+    ? requested.every((value) => rule.patterns.some((pattern) => wildcardMatch(pattern, value)))
+    : rule.patterns.some((pattern) => wildcardMatch(pattern, ""))
+  return (
+    rule.protocol === protocol &&
+    (rule.protocol === "v2" ? rule.directory === directoryKey(permission) : rule.sessionID === permission.sessionID) &&
+    rule.type === permission.type &&
+    patternsMatch
+  )
+}
+
+function directoryKey(permission: Permission) {
+  const directory = permission.metadata.directory
+  return typeof directory === "string" ? directory.replaceAll("\\", "/").replace(/\/+$/, "").toLowerCase() : ""
+}
+
+function requestPatterns(permission: Permission) {
+  return [permission.pattern].flat().filter((value): value is string => typeof value === "string")
+}
+
+function wildcardMatch(pattern: string, value: string) {
+  let expression = pattern
+    .replaceAll("\\", "/")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("*", ".*")
+    .replaceAll("?", ".")
+  if (expression.endsWith(" .*")) expression = expression.slice(0, -3) + "( .*)?"
+  const windows = typeof navigator !== "undefined" && /Windows/i.test(navigator.userAgent)
+  return new RegExp(`^${expression}$`, windows ? "si" : "s").test(value.replaceAll("\\", "/"))
+}
+
+function grantedPatterns(permission: Permission) {
+  const always = permission.metadata.always
+  if (Array.isArray(always) && always.every((value) => typeof value === "string")) return always
+}
+
+export function beginPermissionReply(
+  permission: Permission,
+  response: "once" | "always" | "reject",
+  pending: Permission[],
+  watchdog = replyWatchdogMs,
+) {
+  setMarker(permission.id, "replying", watchdog)
+  if (response !== "always") return
+  const patterns = grantedPatterns(permission)
+  if (!patterns?.length) return
+  const rule = {
+    protocol: (permission as DriftPermission).driftProtocol === "v2" ? ("v2" as const) : ("v1" as const),
+    sessionID: permission.sessionID,
+    directory: directoryKey(permission),
+    type: permission.type,
+    patterns,
+    expires: Date.now() + settleMs,
+  }
+  alwaysRules = [...alwaysRules.filter((item) => item.expires > Date.now()), rule]
+  for (const candidate of pending) if (candidate.id !== permission.id && related(rule, candidate)) settle(candidate)
+}
+
+export function observePermission(permission: Permission, state?: EngineState) {
+  if (markers()[permission.id]) return
+  const now = Date.now()
+  alwaysRules = alwaysRules.filter((rule) => rule.expires > now)
+  if (alwaysRules.some((rule) => related(rule, permission))) {
+    settle(permission)
+    return
+  }
+  const sessions = autoAcceptSessions()
+  if (
+    state &&
+    !autoAcceptGlobal() &&
+    sessions.length > 0 &&
+    !sessions.includes(permission.sessionID) &&
+    !state.sessions[permission.sessionID]?.parentID &&
+    !state.links[permission.sessionID]
+  )
+    settle(permission, lineageSettleMs)
+}
+
+export function failPermissionReply(id: string) {
+  setMarker(id, "failed")
+}
+
+export function clearPermissionAttention(id: string) {
+  setMarkers((current) => {
+    if (!current[id]) return current
+    const next = { ...current }
+    delete next[id]
+    return next
+  })
+}
+
+export function clearPermissionAttentionFor(permissions: Permission[]) {
+  const ids = new Set(permissions.map((permission) => permission.id))
+  setMarkers((current) => {
+    const next = Object.fromEntries(Object.entries(current).filter(([id]) => !ids.has(id)))
+    return Object.keys(next).length === Object.keys(current).length ? current : next
+  })
+}
+
+export function prunePermissionAttention(present: Set<string>) {
+  setMarkers((current) => {
+    const next = Object.fromEntries(Object.entries(current).filter(([id]) => present.has(id)))
+    return Object.keys(next).length === Object.keys(current).length ? current : next
+  })
+}

--- a/src/ui/composer.tsx
+++ b/src/ui/composer.tsx
@@ -3,7 +3,6 @@ import { useEngine } from "../engine"
 import { modelInfo, resolveModel, sessionBusy, type QuestionRequest } from "../engine/store"
 import { emitThreadCreated, transformComposerSubmit } from "../plugins"
 import {
-  autoAcceptAllowed,
   autoAcceptGlobal,
   autoAcceptSessions,
   modelVisible,
@@ -36,6 +35,7 @@ import { shellInvoke } from "../shell"
 import { activeWorkspace, selectWorkspace, workspaces } from "../state/workspaces"
 import { normalizeDir } from "../engine/store"
 import { localAsks, resolveAsk } from "../state/asks"
+import { permissionRequiresAttention, permissionShouldAutoReply } from "../state/permission-attention"
 import { PermissionCard, QuestionCard } from "./attention"
 import { IconMic, IconPaperclip, IconShieldCheck, IconX } from "./icons"
 import { dictationEnabled, dictationModel } from "../state/voice"
@@ -421,16 +421,6 @@ export function Composer() {
     return autoAcceptGlobal() || (!!id && autoAcceptSessions().includes(id))
   }
 
-  function autoAccepted(sessionId: string) {
-    return autoAcceptAllowed(
-      autoAcceptGlobal(),
-      autoAcceptSessions(),
-      sessionId,
-      engine.state.sessions[sessionId]?.parentID,
-      engine.state.links[sessionId],
-    )
-  }
-
   onMount(() => {
     if (dictationEnabled()) void refreshVoiceModels()
     return onKeybind("autoAccept", () => {
@@ -442,14 +432,14 @@ export function Composer() {
 
   createEffect(() => {
     for (const permission of Object.values(engine.state.permissions).flat()) {
-      if (!autoAccepted(permission.sessionID)) continue
+      if (!permissionShouldAutoReply(permission, engine.state)) continue
       untrack(() => void engine.actions.replyPermission(permission.sessionID, permission.id, "once"))
     }
   })
 
   const permissions = () => Object.values(engine.state.permissions).flat()
   const questions = () => Object.values(engine.state.questions).flat()
-  const pendingPermission = () => firstManualPermission(permissions(), (permission) => autoAccepted(permission.sessionID))
+  const pendingPermission = () => firstManualPermission(permissions(), (permission) => !permissionRequiresAttention(permission, engine.state))
   const pendingQuestion = () => focusedQuestion(questions(), focusedQuestionID())
   const pendingAsk = () => localAsks()[0]
 

--- a/src/ui/notifications.tsx
+++ b/src/ui/notifications.tsx
@@ -2,13 +2,11 @@ import { createEffect, createMemo, createSignal, For, onCleanup, Show, untrack }
 import { useEngine, type Engine } from "../engine"
 import {
   alertSounds,
-  autoAcceptAllowed,
-  autoAcceptGlobal,
-  autoAcceptSessions,
   customSound,
   systemNotifications,
   type AttentionKind,
 } from "../state/prefs"
+import { permissionRequiresAttention } from "../state/permission-attention"
 import { selectSession } from "../state/selection"
 import { t } from "../state/i18n"
 import {
@@ -43,22 +41,13 @@ function show(kind: AttentionKind, sessionId: string, title: string, body: strin
 export function AttentionNotifier(props: { engine: Engine }) {
   const seen = new Set<string>()
   createEffect(() => {
-    const all = Object.values(props.engine.state.permissions).flat()
-    const present = new Set(all.map((permission) => permission.id))
+    const pending = Object.values(props.engine.state.permissions).flat()
+    const all = pending.filter((permission) => permissionRequiresAttention(permission, props.engine.state))
+    const present = new Set(pending.map((permission) => permission.id))
     for (const id of seen) if (!present.has(id)) seen.delete(id)
     for (const permission of all) {
       if (seen.has(permission.id)) continue
       seen.add(permission.id)
-      if (
-        autoAcceptAllowed(
-          autoAcceptGlobal(),
-          autoAcceptSessions(),
-          permission.sessionID,
-          props.engine.state.sessions[permission.sessionID]?.parentID,
-          props.engine.state.links[permission.sessionID],
-        )
-      )
-        continue
       untrack(() => {
         const session = props.engine.state.sessions[permission.sessionID]
         show(

--- a/src/ui/parts.tsx
+++ b/src/ui/parts.tsx
@@ -12,6 +12,8 @@ import { codeTokens, Markdown, ProgressiveCodeView, type SyntaxToken } from "./m
 import { diffIndicator, diffLineNumbers, diffWordWrap, syntaxTheme } from "../state/code"
 import { TextShimmer } from "./text-shimmer"
 import { openToolContextMenu } from "./tool-context-menu"
+import { permissionRequiresAttention } from "../state/permission-attention"
+import type { EngineState } from "../engine/store"
 
 export const contextTools = new Set(["read", "glob", "grep", "list"])
 const hiddenTools = new Set(["todowrite", "todoread"])
@@ -285,15 +287,11 @@ function argsPreview(input: Record<string, unknown> | undefined) {
   return joined.length > maxArgsPreviewChars ? joined.slice(0, maxArgsPreviewChars) + "..." : joined
 }
 
-function awaitingPermission(
-  state: {
-    permissions: Record<string, { callID?: string }[]>
-    questions: Record<string, { tool?: { callID: string } }[]>
-  },
-  part: ToolPart,
-) {
+function awaitingPermission(state: EngineState, part: ToolPart) {
   return (
-    (state.permissions[part.sessionID] ?? []).some((permission) => permission.callID === part.callID) ||
+    (state.permissions[part.sessionID] ?? []).some(
+      (permission) => permission.callID === part.callID && permissionRequiresAttention(permission, state),
+    ) ||
     (state.questions[part.sessionID] ?? []).some((question) => question.tool?.callID === part.callID)
   )
 }

--- a/src/ui/workspaces.tsx
+++ b/src/ui/workspaces.tsx
@@ -9,6 +9,7 @@ import type { Workspace } from "../state/store"
 import { fixedMenuPosition } from "../state/zoom"
 import { t } from "../state/i18n"
 import { Chevron } from "./controls"
+import { permissionRequiresAttention } from "../state/permission-attention"
 import { dragReorder } from "./drag-reorder"
 import { activateModal, closeOnBackdropPointerDown } from "./modal"
 import {
@@ -245,11 +246,14 @@ function ThreadItem(props: {
 
 function StatusDot(props: { sessionId: string }) {
   const engine = useEngine()
+  const permissions = () =>
+    (engine.state.permissions[props.sessionId] ?? []).filter((permission) =>
+      permissionRequiresAttention(permission, engine.state),
+    )
   const attention = () =>
-    (engine.state.permissions[props.sessionId]?.length ?? 0) > 0 ||
-    (engine.state.questions[props.sessionId]?.length ?? 0) > 0
+    permissions().length > 0 || (engine.state.questions[props.sessionId]?.length ?? 0) > 0
   const attentionTitle = () =>
-    (engine.state.permissions[props.sessionId]?.length ?? 0) > 0
+    permissions().length > 0
       ? t("drift.thread.waitingForPermission")
       : t("drift.thread.waitingForAnswer")
   return (

--- a/tests/permission-attention.test.ts
+++ b/tests/permission-attention.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, expect, test } from "bun:test"
+import type { Permission } from "@opencode-ai/sdk/client"
+import { createEngineState } from "../src/engine/store"
+import {
+  beginPermissionReply,
+  clearPermissionAttention,
+  failPermissionReply,
+  observePermission,
+  permissionRequiresAttention,
+  type DriftPermission,
+} from "../src/state/permission-attention"
+
+const ids = new Set<string>()
+afterEach(() => {
+  for (const id of ids) clearPermissionAttention(id)
+  ids.clear()
+})
+
+function permission(id: string, sessionID: string, type = "bash"): Permission {
+  ids.add(id)
+  return {
+    id,
+    sessionID,
+    type,
+    messageID: "m1",
+    callID: id,
+    title: type,
+    metadata: {},
+    time: { created: 1 },
+  }
+}
+
+test("permission attention follows global, thread, child, and linked-child auto-accept", () => {
+  const [state, set] = createEngineState()
+  set("sessions", "child", { id: "child", parentID: "parent" } as never)
+  set("links", "linked-child", "linked")
+
+  expect(permissionRequiresAttention(permission("global", "other"), state, { global: true, sessions: [] })).toBeFalse()
+  expect(permissionRequiresAttention(permission("thread", "thread"), state, { global: false, sessions: ["thread"] })).toBeFalse()
+  expect(permissionRequiresAttention(permission("child", "child"), state, { global: false, sessions: ["parent"] })).toBeFalse()
+  expect(
+    permissionRequiresAttention(permission("linked-child", "linked-child"), state, { global: false, sessions: ["linked"] }),
+  ).toBeFalse()
+  expect(permissionRequiresAttention(permission("manual", "other"), state, { global: false, sessions: [] })).toBeTrue()
+})
+
+test("failed automatic replies become manual attention", () => {
+  const [state] = createEngineState()
+  const request = permission("automatic", "s1")
+  beginPermissionReply(request, "once", [request])
+  expect(permissionRequiresAttention(request, state, { global: false, sessions: [] })).toBeFalse()
+  failPermissionReply(request.id)
+  expect(permissionRequiresAttention(request, state, { global: true, sessions: [] })).toBeTrue()
+})
+
+test("a stuck automatic reply is promoted to manual attention", async () => {
+  const [state] = createEngineState()
+  const request = permission("stuck", "s1")
+  beginPermissionReply(request, "once", [request], 1)
+  expect(permissionRequiresAttention(request, state, { global: true, sessions: [] })).toBeFalse()
+  await Bun.sleep(5)
+  expect(permissionRequiresAttention(request, state, { global: true, sessions: [] })).toBeTrue()
+})
+
+test("always replies stabilize queued and immediately following matching requests", () => {
+  const [state] = createEngineState()
+  const original = permission("original", "s1")
+  const queued = permission("queued", "s1")
+  original.pattern = "src/first.ts"
+  original.metadata.always = ["src/**"]
+  queued.pattern = "src/second.ts"
+  const unrelated = permission("unrelated", "s1")
+  unrelated.pattern = "tests/**"
+  beginPermissionReply(original, "always", [original, queued, unrelated])
+  expect(permissionRequiresAttention(queued, state, { global: false, sessions: [] })).toBeFalse()
+  expect(permissionRequiresAttention(unrelated, state, { global: false, sessions: [] })).toBeTrue()
+
+  const immediate = permission("immediate", "s1")
+  immediate.pattern = "src/third.ts"
+  observePermission(immediate)
+  expect(permissionRequiresAttention(immediate, state, { global: false, sessions: [] })).toBeFalse()
+  failPermissionReply(immediate.id)
+  expect(permissionRequiresAttention(immediate, state, { global: false, sessions: [] })).toBeTrue()
+  observePermission(immediate)
+  expect(permissionRequiresAttention(immediate, state, { global: false, sessions: [] })).toBeTrue()
+})
+
+test("v2 always grants stabilize matching requests across sessions in one location", () => {
+  const [state] = createEngineState()
+  const original = permission("v2-original", "s1") as DriftPermission
+  original.driftProtocol = "v2"
+  original.pattern = "git status"
+  original.metadata = { directory: "C:/work", always: ["git *"] }
+  const queued = permission("v2-queued", "s2") as DriftPermission
+  queued.driftProtocol = "v2"
+  queued.pattern = "git diff"
+  queued.metadata.directory = "c:\\work\\"
+  const legacy = permission("v1-queued", "s2")
+  legacy.pattern = "git log"
+  legacy.metadata.directory = "C:/work"
+
+  beginPermissionReply(original, "always", [original, queued, legacy])
+  expect(permissionRequiresAttention(queued, state, { global: false, sessions: [] })).toBeFalse()
+  expect(permissionRequiresAttention(legacy, state, { global: false, sessions: [] })).toBeTrue()
+})

--- a/tests/permission-recovery.test.ts
+++ b/tests/permission-recovery.test.ts
@@ -112,9 +112,14 @@ test("legacy polling does not remove pending v2 permissions", async () => {
     } as never,
     home,
   )
-  globalThis.fetch = (async () => Response.json([])) as typeof fetch
+  const paths: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    paths.push(new URL(String(input)).pathname)
+    return Response.json([])
+  }) as typeof fetch
 
   await actions.refreshPermissions([home])
+  expect(paths).toContain("/permission")
   const request = state.permissions.session?.[0] as DriftPermission
   expect(request.id).toBe("v2")
   expect(request.driftProtocol).toBe("v2")

--- a/tests/permission-recovery.test.ts
+++ b/tests/permission-recovery.test.ts
@@ -3,6 +3,7 @@ import type { Permission } from "@opencode-ai/sdk/client"
 import { createActions } from "../src/engine/actions"
 import { reduce } from "../src/engine/events"
 import { createEngineState, type QuestionRequest } from "../src/engine/store"
+import type { DriftPermission } from "../src/state/permission-attention"
 
 if (!("localStorage" in globalThis))
   Object.defineProperty(globalThis, "localStorage", {
@@ -92,6 +93,32 @@ test("successful scoped snapshots remove confirmed asks but preserve unknown and
   await actions.refreshPermissions([home])
   expect(state.permissions.session?.map((item) => item.id)).toEqual(["unknown", "other"])
   expect(state.questions.session?.map((item) => item.id)).toEqual(["unknown", "other"])
+})
+
+test("legacy polling does not remove pending v2 permissions", async () => {
+  const { state, set, actions } = harness()
+  reduce(
+    set,
+    {
+      type: "permission.v2.asked",
+      properties: {
+        id: "v2",
+        sessionID: "session",
+        action: "bash",
+        resources: ["git status"],
+        save: ["git *"],
+        metadata: {},
+      },
+    } as never,
+    home,
+  )
+  globalThis.fetch = (async () => Response.json([])) as typeof fetch
+
+  await actions.refreshPermissions([home])
+  const request = state.permissions.session?.[0] as DriftPermission
+  expect(request.id).toBe("v2")
+  expect(request.driftProtocol).toBe("v2")
+  expect(request.metadata.always).toEqual(["git *"])
 })
 
 test("new SSE asks survive an older empty polling snapshot", async () => {

--- a/tests/permission-reply.test.ts
+++ b/tests/permission-reply.test.ts
@@ -122,3 +122,24 @@ test("concurrent replies to one permission share the same engine request", async
   expect(state.permissions.s1 ?? []).toHaveLength(0)
   expect(state.notices).toHaveLength(0)
 })
+
+test("v2 permission replies use the protocol endpoint and payload", async () => {
+  const [state, set] = createEngineState()
+  set("directory", home)
+  set("permissions", "s1", [{ ...permission(), metadata: { directory: home }, driftProtocol: "v2" } as Permission])
+  let request!: Request
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    request = input instanceof Request ? input : new Request(input, init)
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  const actions = createActions(
+    () => ({}) as never,
+    state,
+    set,
+    () => ({ url: "http://engine.test" }),
+  )
+
+  expect(await actions.replyPermission("s1", "p1", "always")).toBeTrue()
+  expect(new URL(request.url).pathname).toBe("/api/session/s1/permission/p1/reply")
+  expect(await request.json()).toEqual({ reply: "always" })
+})


### PR DESCRIPTION
## Summary
- centralize manual permission attention across composer, notifications, tool rows, and sidebar
- hide policy-approved and in-flight replies without hiding failed or stuck requests
- stabilize matching queued requests after always replies using engine grant semantics
- support both v1 and v2 permission reply protocols without cross-protocol reconciliation races

## Testing
- bun run typecheck
- bun run test
- bun run build
- git diff --check

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter permission handling that distinguishes requests requiring manual attention from those eligible for automatic responses.
  * Added support for “always” permission choices, including directory and protocol-specific matching.
  * Added compatibility for legacy and v2 permission reply formats.
* **Bug Fixes**
  * Improved recovery for timed-out or failed permission replies.
  * Preserved pending v2 permissions and metadata during legacy polling.
  * Cleared stale permission alerts when sessions are removed or reloaded.
* **Tests**
  * Added coverage for automatic acceptance, permission recovery, matching rules, and v2 replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->