### PR TITLE
Release 1.3.3

### DIFF
--- a/engine/opencode/opencode.json
+++ b/engine/opencode/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@ex-machina/opencode-anthropic-auth@1.8.1"],
+  "plugin": ["@ex-machina/opencode-anthropic-auth@1.8.2"],
   "agent": {
     "orchestrator": {
       "description": "Drives a goal to completion by delegating to subagents, verifying results, and correcting course",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drift",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "drift"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drift"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Drift",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "dev.drift.app",
   "build": {
     "devUrl": "http://localhost:5180",


### PR DESCRIPTION
## Summary
- update the bundled Anthropic auth plugin pin from 1.8.1 to 1.8.2
- stamp Drift 1.3.3

No other changes. The pin stays exact: OpenCode caches npm plugins by literal spec string ( + 'Npm.add' +  in  + 'packages/core/src/npm.ts' + ) and short-circuits when the directory already exists, so an unpinned or ranged spec would freeze on whatever resolved first rather than auto-updating.

## Verification
- bun run typecheck
- bun test tests, 520 passed
- bun run test:release-policy, 18 passed
- cargo test, 62 passed
- bun run build:native, executable reports 1.3.3 and the sidecar reports engine 1.18.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.3.3.
  * Updated the authentication plugin to version 1.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->