### PR TITLE
fix: install frontend resources before native CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Install engine dependencies
+      - name: Install dependencies
         run: |
+          bun install --frozen-lockfile
           bun install --frozen-lockfile --ignore-scripts --cwd engine/upstream
           bun install --frozen-lockfile --cwd engine/opencode
 

--- a/tests/release-policy.test.ts
+++ b/tests/release-policy.test.ts
@@ -297,6 +297,14 @@ test("release workflow gates publication on policy and successful master CI", ()
   expect(workflow).not.toContain("overwrite_files:")
 })
 
+test("native CI installs frontend resource dependencies before running Cargo", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/ci.yml"), "utf8")
+  const full = workflow.slice(workflow.indexOf("  full:"))
+  const install = full.indexOf("          bun install --frozen-lockfile\n")
+  expect(install).toBeGreaterThan(0)
+  expect(full.indexOf("cargo test")).toBeGreaterThan(install)
+})
+
 test("release workflow uses immutable action pins and triggering SHA binding", () => {
   const workflow = readFileSync(path.join(root, ".github/workflows/release.yml"), "utf8")
   const actions = [...workflow.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm)].map((match) => match[1])


### PR DESCRIPTION
## Summary
Fix the 1.3.4 release blocker found by master CI after #104. The Windows job only installed engine dependencies, so Tauri's build script could not find the bundled PDF.js license under node_modules/pdfjs-dist/LICENSE.

Install root frontend dependencies with the frozen lockfile before native tests. Keep the existing engine, native, and release gates intact. No application behavior changes.

## Validation
- bun run test:release-policy: 19 passed.
- Added a regression check that the Windows job installs root dependencies before Cargo.
- The original failure is recorded in CI run 34104159092; full master CI must pass before tagging v1.3.4.

## UI changes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that frontend dependencies are installed before native CI tests run.

* **Chores**
  * Updated the full CI workflow to install root-level dependencies before engine-specific dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->